### PR TITLE
✨ Add the Core SDK to the react-native example

### DIFF
--- a/example/react-native/README.md
+++ b/example/react-native/README.md
@@ -8,17 +8,24 @@ This is a small example app to demonstrate the features of the AeroGear SDK for 
 Make sure that npm and the react native CLI are installed on your system:
 
 ```
-$ brew install npm
-$ npm install -g react-native
+brew install npm
+npm install -g react-native-cli
 ```
 
 ## Try it out
 
+Make sure you have the 'core' package built first. See [../../docs/contributing-guide.adoc](../../docs/contributing-guide.adoc)
+
 You can try the example by running:
 
 ```
-$ npm install
-$ react-native run-<platform>
+# Install dependencies
+# NOTE: This will also install a copy of the core sdk from ../../packages/core
+#       Linking is not possible with react-native currently
+npm install
+
+# Run the app
+react-native run-<platform>
 ```
 
 where `<platform>` can be either `ios` or `android`.

--- a/example/react-native/package.json
+++ b/example/react-native/package.json
@@ -7,6 +7,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@aerogearservices/core": "file:../../packages/core",
     "react": "16.2.0",
     "react-native": "0.53.3",
     "react-navigation": "^1.1.2"

--- a/example/react-native/src/components/StartScreen.js
+++ b/example/react-native/src/components/StartScreen.js
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   TouchableWithoutFeedback
 } from 'react-native';
+import { ConfigService } from '@aerogearservices/core';
 
 const WELCOME_TEXT = "AeroGear SDK Demo";
 
@@ -14,6 +15,9 @@ class StartScreen extends Component {
   }
 
   render() {
+    var mobileServicesJson = require('../mobile-services.json');
+    var config = new ConfigService(mobileServicesJson);
+    var keycloakConfig = config.getKeycloakConfig();
     return (
       <TouchableWithoutFeedback onPress={this.openDrawer.bind(this)}>
         <View style={styles.container}>
@@ -22,6 +26,9 @@ class StartScreen extends Component {
           </Text>
           <Text style={styles.small}>
             Tap to extend drawer
+          </Text>
+          <Text style="{styles.small}">
+            keycloakConfig={JSON.stringify(keycloakConfig)}
           </Text>
         </View>
       </TouchableWithoutFeedback>

--- a/example/react-native/src/mobile-services.json
+++ b/example/react-native/src/mobile-services.json
@@ -1,0 +1,22 @@
+{
+    "version": 1,
+    "clusterName": "https://test.example.com",
+    "namespace": "test",
+    "clientId": "test",
+    "services": [
+        {
+            "id": "keycloak",
+            "name": "keycloak",
+            "type": "keycloak",
+            "url": "https://test.example.com",
+            "config": {
+                "auth-server-url": "https://test.example.com/auth",
+                "clientId": "test",
+                "realm": "test",
+                "resource": "test",
+                "ssl-required": "external",
+                "url": "https://test.example.com/auth"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
* Updated instructions to install the `react-native-cli`
* Core SDK gets installed with `npm install` from the packages folder
* Sample mobile-services.json file added (contents of keycloak config is
shown in example app)