### PR TITLE
browserify example

### DIFF
--- a/example/cordova/README.md
+++ b/example/cordova/README.md
@@ -2,10 +2,16 @@
 
 ## Building
 
+Install the dependencies:
+
+```
+$ npm install
+```
+
 Add platform
 ```
-cordova platform add android
-cordova build android
+$ cordova platform add android
+$ cordova build android
 ```
 
 ## Running
@@ -13,7 +19,8 @@ cordova build android
 Run running platform emulator
 
 ```
-cordova emulate android
+$ npm run browserify
+$ cordova run android
 ```
 
 ## More info

--- a/example/cordova/package.json
+++ b/example/cordova/package.json
@@ -5,14 +5,17 @@
     "description": "Demo cordova example app",
     "main": "index.js",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "install": "node node_modules/browserify/bin/cmd.js www/js/index.js -o www/js/bundle.js",
+        "browserify": "node node_modules/browserify/bin/cmd.js www/js/index.js -o www/js/bundle.js"
     },
     "author": "Apache Cordova Team",
     "license": "Apache-2.0",
     "dependencies": {
+        "browserify": "^16.1.0",
         "cordova-android": "7.0.0",
         "cordova-ios": "4.5.4",
-        "cordova-plugin-whitelist": "^1.3.3"
+        "cordova-plugin-whitelist": "^1.3.3",
+        "@aerogearservices/core": "file:../../packages/core"
     },
     "cordova": {
         "plugins": {

--- a/example/cordova/www/index.html
+++ b/example/cordova/www/index.html
@@ -41,9 +41,10 @@
             <div id="deviceready" class="blink">
                 <p class="event listening">Connecting to Device</p>
                 <p class="event received">Device is Ready</p>
+                <p id="configArea"></p>
             </div>
         </div>
         <script type="text/javascript" src="cordova.js"></script>
-        <script type="text/javascript" src="js/index.js"></script>
+        <script type="text/javascript" src="js/bundle.js"></script>
     </body>
 </html>

--- a/example/cordova/www/js/index.js
+++ b/example/cordova/www/js/index.js
@@ -1,3 +1,5 @@
+const ConfigService = require('@aerogearservices/core').ConfigService;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -28,6 +30,7 @@ var app = {
     // 'pause', 'resume', etc.
     onDeviceReady: function() {
         this.receivedEvent('deviceready');
+        this.loadConfig();
     },
 
     // Update DOM on a Received Event
@@ -40,6 +43,12 @@ var app = {
         receivedElement.setAttribute('style', 'display:block;');
 
         console.log('Received Event: ' + id);
+    },
+
+    loadConfig: function() {
+        const config = new ConfigService(require("../mobile-services"));
+        const configSection = document.getElementById("configArea");
+        configSection.innerText = JSON.stringify(config.getKeycloakConfig());
     }
 };
 

--- a/example/cordova/www/mobile-services.json
+++ b/example/cordova/www/mobile-services.json
@@ -1,0 +1,22 @@
+{
+    "version": 1,
+    "clusterName": "https://test.example.com",
+    "namespace": "test",
+    "clientId": "test",
+    "services": [
+        {
+            "id": "keycloak",
+            "name": "keycloak",
+            "type": "keycloak",
+            "url": "https://test.example.com",
+            "config": {
+                "auth-server-url": "https://test.example.com/auth",
+                "clientId": "test",
+                "realm": "test",
+                "resource": "test",
+                "ssl-required": "external",
+                "url": "https://test.example.com/auth"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Motivation

Makes the Cordova example work with Browserify using the UMD module. Broswerify can be installed locally but in this example i'm adding it to the dependencies and provide a npm script to generate the bundle.