### PR TITLE
Fix Unit tests by adding ts-node

### DIFF
--- a/example/cordova/.gitignore
+++ b/example/cordova/.gitignore
@@ -6,3 +6,4 @@ platforms/*/
 hooks
 merges
 plugins
+bundle.js

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
 		"cleanInstall": "lerna exec npm install --ignore-scripts",
 		"bootstrap": "lerna bootstrap",
 		"lint": "tslint '*/*/src/**/*.ts' '*/*/test/**/*.ts'",
-    "build": "lerna run build",
-    "watch": "lerna run watch",
+		"build": "lerna run build",
+		"watch": "lerna run watch",
 		"clean": "npm-run-all clean:*",
 		"clean:packages": "lerna run clean",
 		"clean:dependencies": "lerna clean --yes",
@@ -27,6 +27,7 @@
 		"opn-cli": "3.1.0",
 		"ts-loader": "^3.5.0",
 		"tslint": "5.8.0",
-		"typescript": "^2.7.2"
+		"typescript": "^2.7.2",
+		"ts-node": "5.0.1"
 	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,8 @@
     "nyc": "11.4.1",
     "sinon": "4.3.0",
     "source-map-support": "0.5.3",
-    "typescript": "2.7.2"
+    "typescript": "2.7.2",
+    "ts-node": "5.0.1"
   },
   "dependencies": {
     "@types/lodash": "4.14.104",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
-    "src/"
+    "src/",
+    "test"
   ],
   "compilerOptions": {
     "outDir": "./dist/",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "noImplicitAny": true,
     "target": "es5",
-    "module": "UMD",
+    "module": "CommonJS",
     "jsx": "react",
     "declaration": true
   },


### PR DESCRIPTION
Fix Unit tests by adding ts-node as dev dependency.
ts-node is required to compile typescript unit tests.