### PR TITLE
fix: path to main module

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@aerogearservices/core",
   "version": "1.0.0",
   "description": "Core SDK for AeroGear services",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "types": "types/index.d.ts",
   "author": "Aerogear <aerogear@googlegroups.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Motivation
Getting errors in bundler after running `react-native run-android`:
https://gist.github.com/psturc/4aab28264d8ef5e7c7b940d4b015e0a6
## Description
As described in the error, the path specified in `packages/core/package.json` was incorrect.