### PR TITLE
WIP Cordova Native Plugin Example

### DIFF
--- a/example/cordova/config.xml
+++ b/example/cordova/config.xml
@@ -17,6 +17,9 @@
     <allow-intent href="geo:*" />
     <platform name="android">
         <allow-intent href="market:*" />
+        <preference name="android-minSdkVersion" value="21" />
+        <edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="merge">
+        </edit-config>
     </platform>
     <platform name="ios">
         <allow-intent href="itms:*" />

--- a/example/cordova/config.xml
+++ b/example/cordova/config.xml
@@ -18,7 +18,7 @@
     <platform name="android">
         <allow-intent href="market:*" />
         <preference name="android-minSdkVersion" value="21" />
-        <edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="merge">
+        <edit-config file="AndroidManifest.xml" mode="merge" target="/manifest/uses-sdk">
         </edit-config>
     </platform>
     <platform name="ios">

--- a/example/cordova/package.json
+++ b/example/cordova/package.json
@@ -5,10 +5,13 @@
   "description": "Demo cordova example app",
   "main": "index.js",
   "scripts": {
-    "install": "node node_modules/browserify/bin/cmd.js www/js/index.js -o www/js/bundle.js",
-    "browserify": "node node_modules/browserify/bin/cmd.js www/js/index.js -o www/js/bundle.js",
+    "postinstall": "npm run browserify && npm run copy-f7",
+    "browserify": "browserify www/js/index.js -o www/js/bundle.js",
     "copy-f7": "cpy node_modules/framework7/dist/js/*.* www/framework7/js && cpy node_modules/framework7/dist/css/*.* www/framework7/css && cpy node_modules/framework7-icons/fonts/*.* www/fonts && cpy node_modules/framework7-icons/css/framework7-icons.css www/css && cpy node_modules/material-design-icons/iconfont/*.{eot,ttf,woff,woff2} www/fonts && cpy node_modules/material-design-icons/iconfont/material-icons.css www/fonts",
-    "postinstall": "npm run copy-f7"
+    "add-platform-android": "cordova platform add android",
+    "add-platform-ios": "cordova platform add ios",
+    "run-android": "cordova run android",
+    "run-ios": "cordova run ios"
   },
   "author": "Apache Cordova Team",
   "license": "Apache-2.0",
@@ -33,5 +36,8 @@
       "android",
       "browser"
     ]
+  },
+  "devDependencies": {
+    "cordova": "^8.0.0"
   }
 }

--- a/example/cordova/package.json
+++ b/example/cordova/package.json
@@ -8,10 +8,10 @@
     "postinstall": "npm run browserify && npm run copy-f7",
     "browserify": "browserify www/js/index.js -o www/js/bundle.js",
     "copy-f7": "cpy node_modules/framework7/dist/js/*.* www/framework7/js && cpy node_modules/framework7/dist/css/*.* www/framework7/css && cpy node_modules/framework7-icons/fonts/*.* www/fonts && cpy node_modules/framework7-icons/css/framework7-icons.css www/css && cpy node_modules/material-design-icons/iconfont/*.{eot,ttf,woff,woff2} www/fonts && cpy node_modules/material-design-icons/iconfont/material-icons.css www/fonts",
-    "add-platform-android": "cordova platform add android",
-    "add-platform-ios": "cordova platform add ios",
-    "run-android": "cordova run android",
-    "run-ios": "cordova run ios"
+    "platform-add-android": "cordova platform add android",
+    "platform-add-ios": "cordova platform add ios",
+    "android": "cordova run android",
+    "ios": "cordova run ios"
   },
   "author": "Apache Cordova Team",
   "license": "Apache-2.0",

--- a/packages/cordova-plugin-aerogear-metrics/package.json
+++ b/packages/cordova-plugin-aerogear-metrics/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cordova-plugin-aerogear-metrics",
+  "version": "1.0.0",
+  "description": "",
+  "cordova": {
+    "id": "cordova-plugin-aerogear-metrics",
+    "platforms": []
+  },
+  "keywords": [
+    "ecosystem:cordova"
+  ],
+  "author": "",
+  "license": "Apache 2.0"
+}

--- a/packages/cordova-plugin-aerogear-metrics/plugin.xml
+++ b/packages/cordova-plugin-aerogear-metrics/plugin.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<plugin id="cordova-plugin-aerogear-metrics" version="1.0.0" 
+  xmlns="http://apache.org/cordova/ns/plugins/1.0" 
+  xmlns:android="http://schemas.android.com/apk/res/android">
+  
+  <name>cordova-plugin-aerogear-metrics</name>
+  
+  <js-module name="cordova-plugin-aerogear-metrics" src="www/cordova-plugin-aerogear-metrics.js">
+    <clobbers target="cordova.plugins.cordova-plugin-aerogear-metrics" />
+  </js-module>
+
+  <platform name="android">
+    <framework custom="true" src="src/android/build.gradle" type="gradleReference" />
+
+    <config-file parent="/*" target="res/xml/config.xml">
+      <feature name="CordovaPluginAeroGearMetrics">
+        <param name="android-package" value="aerogear.metrics.CordovaPluginAeroGearMetrics" />
+      </feature>
+    </config-file>
+
+    <config-file parent="/*" target="AndroidManifest.xml"></config-file>
+    <source-file src="src/android/CordovaPluginAeroGearMetrics.java" target-dir="src/cordova-plugin-aerogear-metrics/cordova-plugin-aerogear-metrics" />
+  </platform>
+
+</plugin>

--- a/packages/cordova-plugin-aerogear-metrics/src/android/CordovaPluginAeroGearMetrics.java
+++ b/packages/cordova-plugin-aerogear-metrics/src/android/CordovaPluginAeroGearMetrics.java
@@ -1,0 +1,34 @@
+package aerogear.metrics;
+
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CallbackContext;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import org.aerogear.mobile.core.*;
+
+/**
+ * This class echoes a string called from JavaScript.
+ */
+public class CordovaPluginAeroGearMetrics extends CordovaPlugin {
+
+    @Override
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        if (action.equals("myFunc")) {
+            String message = args.getString(0);
+            this.myFunc(message, callbackContext);
+            return true;
+        }
+        return false;
+    }
+
+    private void myFunc(String message, CallbackContext callbackContext) {
+        if (message != null && message.length() > 0) {
+            callbackContext.success(message);
+        } else {
+            callbackContext.error("Expected one non-empty string argument.");
+        }
+    }
+}

--- a/packages/cordova-plugin-aerogear-metrics/src/android/build.gradle
+++ b/packages/cordova-plugin-aerogear-metrics/src/android/build.gradle
@@ -8,6 +8,6 @@ allprojects {
 }
 
 dependencies {
-    implementation 'org.aerogear:auth:0.1.0-2018-09'
+    // implementation 'org.aerogear:auth:0.1.0-2018-09'
     implementation 'org.aerogear:core:0.1.0-2018-09'
 }

--- a/packages/cordova-plugin-aerogear-metrics/src/android/build.gradle
+++ b/packages/cordova-plugin-aerogear-metrics/src/android/build.gradle
@@ -1,0 +1,13 @@
+allprojects {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        google()
+        jcenter()
+    }
+}
+
+dependencies {
+    implementation 'org.aerogear:auth:0.1.0-2018-09'
+    implementation 'org.aerogear:core:0.1.0-2018-09'
+}

--- a/packages/cordova-plugin-aerogear-metrics/www/cordova-plugin-aerogear-metrics.js
+++ b/packages/cordova-plugin-aerogear-metrics/www/cordova-plugin-aerogear-metrics.js
@@ -1,0 +1,11 @@
+var exec = require('cordova/exec');
+
+console.log('This message is brought to you by a cordova plugin')
+
+if (!window.aerogear) {
+    window.aerogear = {}
+}
+
+window.aerogear.myFunc = function (arg0, success, error) {
+    exec(success, error, 'CordovaPluginAeroGearMetrics', 'myFunc', [arg0]);
+};


### PR DESCRIPTION
## Description

This PR puts in place an example of how to write a cordova plugin that makes calls into native android code. The native CordovaPluginAeroGearMetrics.java class could be used to make calls to native SDKS

What it does:

- adds some helper scripts to the cordova app's `package.json`
- adds a cordova plugin that only works on android
- Successfully imports the core sdk. Note there is a commented out statement for the auth sdk.
- creates a function which can be accessed at window.aerogear.myFunc()
- Usage is as follows:

```
window.cordova.myFunc("foo", successCallback, errorCallback)
```

The string arg is passed down to the native layer and the native layer simply returns the same string as a result. It is in this place that we could make calls to the native SDKS and return a result.

The build fails if we try to include the auth sdk with the following error:

```
ommand failed with exit code 1 Error output:
/Users/dara/mcp/aerogear-js-sdk/example/cordova/platforms/android/app/src/main/AndroidManifest.xml Error:
        Attribute data@scheme at AndroidManifest.xml requires a placeholder substitution but no value for <appAuthRedirectScheme> is provided.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:processDebugManifest'.
> Manifest merger failed : Attribute data@scheme at AndroidManifest.xml requires a placeholder substitution but no value for <appAuthRedirectScheme> is provided.
```

This means we need to figure out a way to put stuff in the the cordova application's config.xml and have it passed into the AndroidManifest.xml as part of the build. (and the same for iOS).

### How to run

* cd into `example/cordova`
* `npm install`
* `npm run platform-add-android`
* `npm run android`

And if you go to `chrome://inspect` and access the javascript console you should be able to access the `window.aerogear` global object. Alternatively add some code to the cordova app to call `window.aerogear.myFunc()`.

## TODO
- [ ] Figure out how to do the same with iOS
- [ ] Figure out how to inject additional configs required by SDKS into things like AndroidManifest.xml (and whatever iOS uses) e.g. so auth can work.
- [ ] Documentation

Most of metrics could be implemented in js, with the exception of the Self Defence checks, so perhaps that's the only native thing we need to do.

Please note I won't be back until thursday so if anyone wants to take this up, please feel free.
