### PR TITLE
Remove build

### DIFF
--- a/packages/core-cordova/package.json
+++ b/packages/core-cordova/package.json
@@ -11,8 +11,7 @@
     ]
   },
   "scripts": {
-    "bundle": "node_modules/.bin/browserify dist/MobileCore.js -o dist/core-cordova.js",
-    "build": "node_modules/.bin/tsc && npm run bundle",
+    "build": "node_modules/.bin/tsc",
     "clean": "rm -rf dist node_modules src/*.js src/*.map types",
     "clean:build": "npm run clean && npm install && npm run build"
   },

--- a/packages/core-cordova/plugin.xml
+++ b/packages/core-cordova/plugin.xml
@@ -9,15 +9,15 @@
     <license>Apache 2.0</license>
     <keywords>cordova,aerogear,mobile</keywords>
 
-    <js-module src="dist/core-cordova.js" name="core-cordova">
-        <clobbers target="cordova.aerogear.core" />
+     <js-module src="dist/MobileCore.js" name="core-cordova">
+        <!-- <clobbers target="aerogear_core" /> -->
     </js-module>
 
     <platform name="android">
-        <config-file target="res/xml/config.xml" parent="/*"> 
+        <config-file target="res/xml/config.xml" parent="/*">
             <feature name="MobileCoreModule" >
                 <param
-                    name="android-package" 
+                    name="android-package"
                     value="org.aerogear.mobile.core.MobileCoreModule"
                 />
             </feature>
@@ -27,9 +27,9 @@
             <!-- Add permissions here -->
         </config-file>
 
-        <source-file 
-            src="src/android/MobileCoreModule.java" 
-            target-dir="src/org/aerogear/mobile/core/MobileCoreModule" 
+        <source-file
+            src="src/android/MobileCoreModule.java"
+            target-dir="src/org/aerogear/mobile/core/MobileCoreModule"
         />
     </platform>
 


### PR DESCRIPTION
This will mount to `window.MobileCore` 

Clobbers is ignored (seems like bug and let's not use it). We can expose stuff with namespace internally.