### PR TITLE
Adds missing metric in Android module

### DIFF
--- a/packages/core-cordova/src/android/MobileCoreModule.java
+++ b/packages/core-cordova/src/android/MobileCoreModule.java
@@ -71,6 +71,8 @@ public class MobileCoreModule extends CordovaPlugin {
 
     final JSONObject appMetrics = new JSONObject();
     appMetrics.put("appId", packageName);
+    // sdkVersion is included in package.json, it must be added by JS interface
+    appMetrics.put("sdkVersion", "");
     appMetrics.put("appVersion", packageInfo.versionName);
 
     return appMetrics;


### PR DESCRIPTION
## Description
`sdkVersion` metrics must be added by the JavaScript interface, however for explicitness it should be added in the Android module. This way if for some reason the value is not added by JS code, the element will still be there in the metrics payload.

The way this metrics is set is something like:
```javascript
function sendAppAndDeviceMetrics() {
  this.getAppAndDeviceMetricsFromNativeModule()
    .then(metrics => {
      metrics.app.sdkVersion = this.getPluginVersionFromWherever();

      // publish
    });
}
