### PR TITLE
Add metrics type

### DIFF
--- a/packages/core/src/metrics/MetricsService.ts
+++ b/packages/core/src/metrics/MetricsService.ts
@@ -1,6 +1,6 @@
 import uuid from "uuid/v1";
 import { ServiceConfiguration } from "../configuration";
-import { Metrics, MetricsPayload } from "./model";
+import { Metrics, MetricsPayload, MetricsType } from "./model";
 import { MetricsPublisher, NetworkMetricsPublisher } from "./publisher";
 
 /**
@@ -31,11 +31,17 @@ export abstract class MetricsService {
     /**
      * Publish metrics using predefined publisher
      *
-     * @param - metrics instances that should be published
+     * @param type type of the metrics to be published
+     * @param metrics metrics instances that should be published
      */
-    public publish(metrics: Metrics[]): Promise<any> {
+    public publish(type: MetricsType, metrics: Metrics[]): Promise<any> {
+        if (!type) {
+            throw new Error(`Type is invalid: ${type}`);
+        }
+
         const payload: MetricsPayload = {
             clientId: this.getClientId(),
+            type,
             timestamp: new Date().getTime(),
             data: {}
         };

--- a/packages/core/src/metrics/model/MetricsPayload.ts
+++ b/packages/core/src/metrics/model/MetricsPayload.ts
@@ -1,6 +1,9 @@
+import { MetricsType } from "./";
+
 export interface MetricsPayload {
 
   clientId: string;
+  type: MetricsType;
   timestamp?: number;
   data: any;
 

--- a/packages/core/src/metrics/model/MetricsType.ts
+++ b/packages/core/src/metrics/model/MetricsType.ts
@@ -1,0 +1,1 @@
+export type MetricsType = "init" | "security";

--- a/packages/core/src/metrics/model/index.ts
+++ b/packages/core/src/metrics/model/index.ts
@@ -2,3 +2,4 @@ export { AppMetrics } from "./AppMetrics";
 export { DeviceMetrics } from "./DeviceMetrics";
 export { Metrics } from "./Metrics";
 export { MetricsPayload } from "./MetricsPayload";
+export { MetricsType } from "./MetricsType";

--- a/packages/core/src/metrics/publisher/index.ts
+++ b/packages/core/src/metrics/publisher/index.ts
@@ -1,2 +1,2 @@
-export { MetricsPublisher } from "./MetricsPublisher";
+export { MetricsPublisher, MetricsType } from "./MetricsPublisher";
 export { NetworkMetricsPublisher } from "./NetworkMetricsPublisher";

--- a/packages/core/test/metrics/MetricsService.ts
+++ b/packages/core/test/metrics/MetricsService.ts
@@ -8,6 +8,7 @@ import {
   MetricsPayload,
   MetricsPublisher,
   MetricsService,
+  MetricsType,
   NetworkMetricsPublisher
 } from "../../src/metrics";
 import testAerogearConfig from "../mobile-config.json";
@@ -24,79 +25,108 @@ describe("MetricsService", () => {
     storage.clientId = null;
   });
 
-  it("should have a NetworkMetricsPublisher by default", () => {
-    const defaultPublisher = metricsService.metricsPublisher;
+  describe("#constructor", () => {
 
-    expect(defaultPublisher).to.be.instanceOf(NetworkMetricsPublisher);
+    it("should have a NetworkMetricsPublisher by default", () => {
+      const defaultPublisher = metricsService.metricsPublisher;
+
+      expect(defaultPublisher).to.be.instanceOf(NetworkMetricsPublisher);
+    });
+
+    it("should instantiate NetworkMetricsPublisher with configuration url", () => {
+      const { url } = metricsConfig;
+      const publisher = metricsService.metricsPublisher as NetworkMetricsPublisher;
+
+      assert.equal(url, publisher.url);
+    });
+
   });
 
-  it("should instantiate NetworkMetricsPublisher with configuration url", () => {
-    const { url } = metricsConfig;
-    const publisher = metricsService.metricsPublisher as NetworkMetricsPublisher;
+  describe("#setPublisher", () => {
 
-    assert.equal(url, publisher.url);
+    it("should be possible to override the publisher", async () => {
+      const customPublisher = new MockMetricsPublisher();
+      const spy = sinon.spy(customPublisher, "publish");
+      metricsService.metricsPublisher = customPublisher;
+
+      const res = await metricsService.publish("init", []);
+
+      sinon.assert.calledOnce(spy);
+    });
+
   });
 
-  it("should be possible to override the publisher", async () => {
-    const customPublisher = new MockMetricsPublisher();
-    const spy = sinon.spy(customPublisher, "publish");
-    metricsService.metricsPublisher = customPublisher;
+  describe("#publish", () => {
 
-    const res = await metricsService.publish([]);
+    it("should publish a MetricsPayload from an array of Metrics", async () => {
+      const mockPublisher = new MockMetricsPublisher();
+      const spy = sinon.spy(mockPublisher, "publish");
+      metricsService.metricsPublisher = mockPublisher;
 
-    sinon.assert.calledOnce(spy);
+      const type = "init";
+      const metrics: Metrics[] = [
+        { identifier: "someNumber", collect: () => 123 },
+        { identifier: "someString", collect: () => "foo" }
+      ];
+      const matcher: MetricsPayload = {
+        clientId: metricsService.getClientId(),
+        type,
+        data: {
+          someNumber: 123,
+          someString: "foo"
+        }
+      };
+
+      metricsService.publish(type, metrics);
+
+      sinon.assert.calledWithMatch(spy, matcher);
+    });
+
+    it("should throw an error is type is null", () => {
+      const test = () => metricsService.publish(null, []);
+
+      expect(test).to.throw("Type is invalid: null");
+    });
+
+    it("should throw an error is type is undefined", () => {
+      const test = () => metricsService.publish(undefined, []);
+
+      expect(test).to.throw("Type is invalid: undefined");
+    });
+
   });
 
-  it("should publish a MetricsPayload from an array of Metrics", async () => {
-    const mockPublisher = new MockMetricsPublisher();
-    const spy = sinon.spy(mockPublisher, "publish");
-    metricsService.metricsPublisher = mockPublisher;
+  describe("#getClientId", () => {
 
-    const metrics: Metrics[] = [
-      { identifier: "someNumber", collect: () => 123 },
-      { identifier: "someString", collect: () => "foo" }
-    ];
+    it("should generate a string client id", () => {
+      const id = metricsService.getClientId();
 
-    metricsService.publish(metrics);
+      assert.isString(id);
+    });
 
-    const matcher: MetricsPayload = {
-      clientId: metricsService.getClientId(),
-      data: {
-        someNumber: 123,
-        someString: "foo"
-      }
-    };
+    it("should save the client id when getting for first time", () => {
+      assert.isNull(storage.clientId);
+      const id = metricsService.getClientId();
 
-    sinon.assert.calledWithMatch(spy, matcher);
-  });
+      assert.equal(storage.clientId, id);
+    });
 
-  it("should generate a string client id", () => {
-    const id = metricsService.getClientId();
+    it("should generate a new unique clientID if none is saved", () => {
+      const id = metricsService.getClientId();
+      // Remove id from storage, as if it was a different device
+      storage.clientId = null;
+      const newId = metricsService.getClientId();
 
-    assert.isString(id);
-  });
+      assert.notEqual(id, newId);
+    });
 
-  it("should save the client id when getting for first time", () => {
-    assert.isNull(storage.clientId);
-    const id = metricsService.getClientId();
+    it("should return the same clientID after the first time", () => {
+      const id = metricsService.getClientId();
+      const newId = metricsService.getClientId();
 
-    assert.equal(storage.clientId, id);
-  });
+      assert.equal(id, newId);
+    });
 
-  it("should generate a new unique clientID if none is saved", () => {
-    const id = metricsService.getClientId();
-    // Remove id from storage, as if it was a different device
-    storage.clientId = null;
-    const newId = metricsService.getClientId();
-
-    assert.notEqual(id, newId);
-  });
-
-  it("should return the same clientID after the first time", () => {
-    const id = metricsService.getClientId();
-    const newId = metricsService.getClientId();
-
-    assert.equal(id, newId);
   });
 
   class MockMetricsService extends MetricsService {

--- a/packages/core/test/metrics/publiser/NetworkMetricsPublisher.ts
+++ b/packages/core/test/metrics/publiser/NetworkMetricsPublisher.ts
@@ -14,8 +14,9 @@ import testAerogearConfig from "../../mobile-config.json";
 
 describe("NetworkMetricsPublisher", () => {
 
-  const validMetrics = {
+  const validMetrics: MetricsPayload = {
     clientId: "123",
+    type: "init",
     data: {}
   };
 

--- a/packages/core/test/metrics/publiser/NetworkMetricsPublisher.ts
+++ b/packages/core/test/metrics/publiser/NetworkMetricsPublisher.ts
@@ -20,7 +20,7 @@ describe("NetworkMetricsPublisher", () => {
   };
 
   const mockServer = mockttp.getLocal();
-  let publisher;
+  let publisher: NetworkMetricsPublisher;
 
   before(async () => {
     await mockServer.start();

--- a/packages/core/test/metrics/publiser/NetworkMetricsPublisher.ts
+++ b/packages/core/test/metrics/publiser/NetworkMetricsPublisher.ts
@@ -35,7 +35,7 @@ describe("NetworkMetricsPublisher", () => {
 
   describe("#publish", () => {
 
-    it("should return 204 is metrics are published", async () => {
+    it("should return 204 if metrics are published", async () => {
       const res = await publisher.publish(validMetrics);
 
       assert.equal(res.status, 204);


### PR DESCRIPTION
## Description
Adds the field `type` to the metrics payload. It is defined as a type with values `"init"` or `"security"` and it's extendable. This definition allows intellisense in Typescript.
