### PR TITLE
Revert config helper methods

### DIFF
--- a/packages/core/src/configuration/ConfigurationParser.ts
+++ b/packages/core/src/configuration/ConfigurationParser.ts
@@ -4,7 +4,11 @@ import { AeroGearConfiguration, ServiceConfiguration } from "./";
 /**
  * List of types of all supported services.
  */
-export type ServiceType = "metrics" | "keycloak" | "push" | any;
+export enum ServiceType {
+  METRICS = "metrics",
+  KEYCLOAK = "keycloak",
+  PUSH = "push"
+}
 
 /**
  * Represents a configuration parser.
@@ -21,7 +25,33 @@ export class ConfigurationParser {
     this.configurations = config.services || [];
   }
 
-  public getConfig(type: ServiceType): ServiceConfiguration | undefined {
+  /**
+   * Get Metrics service configuration object
+   */
+  public getMetricsConfig(): ServiceConfiguration | undefined {
+    return this.getConfig(ServiceType.METRICS);
+  }
+
+  /**
+   * Get Keycloak service configuration object
+   */
+  public getKeycloakConfig(): ServiceConfiguration | undefined {
+    return this.getConfig(ServiceType.KEYCLOAK);
+  }
+
+  /**
+   * Get Push service configuration object
+   */
+  public getPushConfig(): ServiceConfiguration | undefined {
+    return this.getConfig(ServiceType.PUSH);
+  }
+
+  /**
+   * Get a service configuration object, provided an existing type is given
+   * @param type string - The type of the service
+   */
+  public getConfig(type: string): ServiceConfiguration | undefined {
     return find(this.configurations, service => service.type === type);
   }
+
 }

--- a/packages/core/test/configuration/ConfigurationParser.ts
+++ b/packages/core/test/configuration/ConfigurationParser.ts
@@ -40,24 +40,36 @@ describe("ConfigurationParser", () => {
     });
   });
 
-  describe("#getService", () => {
+  describe("#getConfig", () => {
 
     it("should return undefined if using an nonexistent key", () => {
-      const result = parser.getConfig("foo" as any);
+      const result = parser.getConfig("foo");
 
       assert.isUndefined(result);
     });
 
-    it("should be able to get keycloak config", () => {
-      const keycloakConfig = parser.getConfig("keycloak");
+    it("should be able to get config if its key exists", () => {
+      const result = parser.getConfig("keycloak");
 
-      assert.equal(keycloakConfig.name, "keycloak");
+      expect(result.type).to.equal("keycloak");
+    });
+
+    it("should be able to get keycloak config", () => {
+      const keycloakConfig = parser.getKeycloakConfig();
+
+      assert.equal(keycloakConfig.type, "keycloak");
     });
 
     it("should be able to get metrics config", () => {
-      const metricsConfig = parser.getConfig("metrics");
+      const metricsConfig = parser.getMetricsConfig();
 
-      assert.equal(metricsConfig.name, "metrics");
+      assert.equal(metricsConfig.type, "metrics");
+    });
+
+    it("should be able to get push config", () => {
+      const metricsConfig = parser.getPushConfig();
+
+      assert.equal(metricsConfig.type, "push");
     });
 
   });

--- a/packages/core/test/mobile-config.json
+++ b/packages/core/test/mobile-config.json
@@ -4,21 +4,26 @@
   "namespace": "myproject",
   "clientId": "example_client_id",
   "services": [
-      {
-          "id": "keycloak",
-          "name": "keycloak",
-          "type": "keycloak",
-          "url": "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6",
-          "config": {
-          }
-      },
-      {
-        "id": "metrics",
-        "name": "metrics",
-        "type": "metrics",
-        "url": "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6",
-        "config": {
-        }
+    {
+      "id": "keycloak",
+      "name": "keycloak",
+      "type": "keycloak",
+      "url": "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6",
+      "config": {}
+    },
+    {
+      "id": "metrics",
+      "name": "metrics",
+      "type": "metrics",
+      "url": "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6",
+      "config": {}
+    },
+    {
+      "id": "push",
+      "name": "push",
+      "type": "push",
+      "url": "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6",
+      "config": {}
     }
   ]
 }


### PR DESCRIPTION
## Description
Revert to the helper methods `getMetricsConfig()`, etc. 

`ServiceType` is now an enum that define the service type names as constants.