### PR TITLE
fix: add repository and issue tracker links to packages

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -5,6 +5,13 @@
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "author": "Aerogear <aerogear@googlegroups.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aerogear/aerogear-js-sdk.git"
+  },
+  "bugs": {
+    "url": "https://issues.jboss.org/projects/AGCORDOVA/issues"
+  },
   "keywords": [
     "aerogear",
     "mobile",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,13 @@
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "author": "AeroGear <aerogear@googlegroups.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aerogear/aerogear-js-sdk.git"
+  },
+  "bugs": {
+    "url": "https://issues.jboss.org/projects/AGCORDOVA/issues"
+  },
   "keywords": [
     "aerogear",
     "mobile"


### PR DESCRIPTION
## Motivation
Make it easier for developers browsing npm to find the source repository here on GitHub.

## Description
Simple enough change that adds "repository" and "bugs" keys to the package.json of each module.

