### PR TITLE
fix: add configurable logger to SDK

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@types/chai": "4.1.2",
     "@types/chai-as-promised": "7.1.0",
+    "@types/loglevel": "^1.5.3",
     "@types/mocha": "^5.0.0",
     "@types/node": "^9.4.6",
     "@types/proxyquire": "1.3.28",
@@ -68,6 +69,7 @@
   "dependencies": {
     "@aerogear/core": "0.2.0",
     "keycloak-js": "4.0.0-beta.1",
+    "loglevel": "^1.6.1",
     "url": "^0.11.0"
   }
 }

--- a/packages/auth/src/AuthService.ts
+++ b/packages/auth/src/AuthService.ts
@@ -1,6 +1,7 @@
 import { AeroGearConfiguration, ConfigurationHelper, ServiceConfiguration } from "@aerogear/core";
 import Keycloak from "keycloak-js";
 import { KeycloakError, KeycloakInitOptions, KeycloakInstance, KeycloakProfile, KeycloakPromise } from "keycloak-js";
+import console from "loglevel";
 
 /**
  * Wrapper class for {Keycloak.KeycloakInstance}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,6 +48,7 @@
     "@types/chai": "4.1.2",
     "@types/chai-as-promised": "7.1.0",
     "@types/lodash.find": "^4.6.3",
+    "@types/loglevel": "^1.5.3",
     "@types/mocha": "^5.0.0",
     "@types/node": "^9.4.6",
     "@types/proxyquire": "1.3.28",
@@ -68,6 +69,7 @@
   "dependencies": {
     "axios": "0.18.0",
     "lodash.find": "^4.6.0",
+    "loglevel": "^1.6.1",
     "uuid": "^3.2.1"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,8 @@
 /**
  * @module @aerogearservices/core
  */
+import console from "loglevel";
+console.setDefaultLevel(console.levels.WARN);
 
 // Configuration parsers
 export * from "./configuration";

--- a/packages/core/src/metrics/MetricsService.ts
+++ b/packages/core/src/metrics/MetricsService.ts
@@ -1,3 +1,4 @@
+import console from "loglevel";
 import uuid from "uuid/v1";
 import { AeroGearConfiguration, ConfigurationHelper, ServiceConfiguration } from "../configuration";
 import { Metrics, MetricsPayload } from "./model";
@@ -5,7 +6,6 @@ import { CordovaAppMetrics } from "./platform/CordovaAppMetrics";
 import { CordovaDeviceMetrics } from "./platform/CordovaDeviceMetrics";
 import { isMobileCordova } from "./platform/PlatformUtils";
 import { MetricsPublisher, NetworkMetricsPublisher } from "./publisher";
-
 declare var window: any;
 
 /**


### PR DESCRIPTION
## Motivation

Add option to kill logging or extend it. We could add more debug stuff after and disable it for end users.