### PR TITLE
User api experiment

### DIFF
--- a/packages/app/.npmignore
+++ b/packages/app/.npmignore
@@ -1,0 +1,4 @@
+test/
+coverage/
+.nyc_output/
+node_modules/

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@aerogear/app",
+  "version": "0.1.0",
+  "description": "AeroGear Services main module used for configuration purposes",
+  "main": "dist/index.js",
+  "types": "types/index.d.ts",
+  "author": "Aerogear <aerogear@googlegroups.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aerogear/aerogear-js-sdk.git"
+  },
+  "bugs": {
+    "url": "https://issues.jboss.org/projects/AGCORDOVA/issues"
+  },
+  "keywords": [
+    "aerogear",
+    "mobile",
+    "keycloak",
+    "sso",
+    "auth",
+    "openid"
+  ],
+  "license": "Apache-2.0",
+  "scripts": {
+    "clean": "del coverage src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "test": "nyc mocha"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "nyc": {
+    "include": [
+      "src/**/*.ts"
+    ],
+    "extension": [
+      ".ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "lines": 75,
+    "functions": 100,
+    "branches": 80
+  },
+  "devDependencies": {
+    "@types/chai": "4.1.2",
+    "@types/chai-as-promised": "7.1.0",
+    "@types/mocha": "^5.0.0",
+    "@types/node": "^9.4.6",
+    "@types/proxyquire": "1.3.28",
+    "@types/sinon": "^4.3.1",
+    "chai": "4.1.2",
+    "chai-as-promised": "7.1.1",
+    "del-cli": "1.1.0",
+    "mocha": "^5.0.5",
+    "nyc": "^11.6.0",
+    "sinon": "^4.5.0",
+    "source-map-support": "^0.5.4",
+    "ts-node": "5.0.1",
+    "typescript": "^2.8.1"
+  },
+  "dependencies": {
+    "@aerogear/core": "0.2.0",
+    "keycloak-js": "4.0.0-beta.1",
+    "url": "^0.11.0"
+  }
+}

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -1,0 +1,17 @@
+import { AeroGearConfiguration, ConfigurationHelper } from "@aerogear/core";
+
+declare var window: any;
+
+let config: ConfigurationHelper;
+
+export function init(configuration: AeroGearConfiguration) {
+  config = new ConfigurationHelper(configuration);
+  window.Metrics.init(config);
+}
+
+export function getAuth() {
+  if (config && window.Auth) {
+    window.Auth.init(config);
+    return window.Auth;
+  }
+}

--- a/packages/app/test/mocha.opts
+++ b/packages/app/test/mocha.opts
@@ -1,0 +1,3 @@
+--compilers ts:ts-node/register
+--require source-map-support/register
+test/**/**.ts

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": [
+      "src/"
+    ],
+    "compilerOptions": {
+      "outDir": "./dist/",
+      "declarationDir": "./types"
+    }
+  }
+  


### PR DESCRIPTION
## Motivation

I was thinking how we can satisfy end user api requirements and also metrics auto init. Our requirements are:

1) Allow each SDK to be fully independent
2) Allow us to maintain configuration and SDK initialization inside SDK instead of users being responsible for that.
3) [Technical] Avoid circular dependencies (auth depending on core and core on auth)
4) Allow full web support when we compile packages to plain bundled js code for independent libraries.

Happy for us there are many examples for such usage. 
For example: https://firebase.google.com/docs/web/setup

TL;DR - we need new package that will be aggregating all SDK's and making sure that they will receive config.

## IDEA 

Users will just do
```
<script src="aerogear-app.js"></script>
// common.js version
var app = require("@aerogear/app")
app.initialize(config);
let auth = app.getAuth();
```

However having it this way (bundle all in app) will jeopardize point 1) of having independent packages. In this PR I'm going to spike how we can get all the goodness and flexible user api without jeopardizing all the points. I will also try to provide early support for the web to spike how this could work.

This idea is also going to resolve couple problems:
- autoconfiguration of the push plugin variants.
- making metrics work outside the box. Currently it happens in user space which is not desired: https://github.com/aerogear/cordova-showcase-template/blob/master/src/services/metrics.ts

Note: This is the raw idea that needs to be spiked for all options. 
See commit: 863408e73a0c1f4ab9d789a9daef28da4d5a8d96

Concerns: this change will affect separation for SDK's as they going to be exposed in global window objects. 

