### PR TITLE
fix: use type for config

### DIFF
--- a/docs/core.adoc
+++ b/docs/core.adoc
@@ -38,6 +38,6 @@ import { ConfigurationHelper } from '@aerogear/core';
 import appConfiguration from '../mobile-services.json';
 
 const helper = new ConfigurationHelper(appConfiguration);
-const metricsConfig = helper.getConfig(MetricsService.ID);
+const metricsConfig = helper.getConfigByType(MetricsService.ID);
 ----
 

--- a/docs/core.adoc
+++ b/docs/core.adoc
@@ -38,6 +38,6 @@ import { ConfigurationHelper } from '@aerogear/core';
 import appConfiguration from '../mobile-services.json';
 
 const helper = new ConfigurationHelper(appConfiguration);
-const metricsConfig = helper.getConfigByType(MetricsService.ID);
+const metricsConfig = helper.getConfigByType(MetricsService.TYPE);
 ----
 

--- a/packages/auth/src/AuthService.ts
+++ b/packages/auth/src/AuthService.ts
@@ -13,14 +13,14 @@ export class AuthService {
   private auth: KeycloakInstance;
 
   constructor(appConfig: AeroGearConfiguration) {
-    const configuration = new ConfigurationHelper(appConfig).getConfig(AuthService.ID);
+    const configuration = new ConfigurationHelper(appConfig).getConfigByType(AuthService.ID);
     let internalConfig;
 
-    if (!configuration) {
+    if (!configuration || configuration.length === 0) {
       console.warn("Keycloak configuration is missing. Authentication will not work properly.");
       internalConfig = {};
     } else {
-      internalConfig = configuration.config;
+      internalConfig = configuration[0].config;
     }
 
     this.auth = Keycloak(internalConfig);

--- a/packages/auth/src/AuthService.ts
+++ b/packages/auth/src/AuthService.ts
@@ -8,12 +8,12 @@ import console from "loglevel";
  */
 export class AuthService {
 
-  public static readonly ID: string = "keycloak";
+  public static readonly TYPE: string = "keycloak";
 
   private auth: KeycloakInstance;
 
   constructor(appConfig: AeroGearConfiguration) {
-    const configuration = new ConfigurationHelper(appConfig).getConfigByType(AuthService.ID);
+    const configuration = new ConfigurationHelper(appConfig).getConfigByType(AuthService.TYPE);
     let internalConfig;
 
     if (!configuration || configuration.length === 0) {

--- a/packages/core/src/configuration/ConfigurationHelper.ts
+++ b/packages/core/src/configuration/ConfigurationHelper.ts
@@ -17,10 +17,10 @@ export class ConfigurationHelper {
 
   /**
    * Get a service configuration object, provided an existing id is given
-   * @param id string - The id of the service
+   * @param type string - The type of the service
    */
-  public getConfig(id: string): ServiceConfiguration | undefined {
-    return find(this.configurations, service => service.id.toLowerCase() === id.toLowerCase());
+  public getConfig(type: string): ServiceConfiguration | undefined {
+    return find(this.configurations, service => service.type.toLowerCase() === type.toLowerCase());
   }
 
 }

--- a/packages/core/src/configuration/ConfigurationHelper.ts
+++ b/packages/core/src/configuration/ConfigurationHelper.ts
@@ -16,11 +16,11 @@ export class ConfigurationHelper {
   }
 
   /**
-   * Get a service configuration object, provided an existing id is given
+   * Get a service configuration object, provided an existing type is given
    * @param type - The type of the service
    */
-  public getConfig(type: string): ServiceConfiguration | undefined {
-    return find(this.configurations, service => service.type.toLowerCase() === type.toLowerCase());
+  public getConfigByType(type: string): ServiceConfiguration[] | undefined {
+    return this.configurations.filter(service => service.type.toLowerCase() === type.toLowerCase());
   }
 
   /**
@@ -28,7 +28,7 @@ export class ConfigurationHelper {
    * @param id - unique id of the service
    */
   public getConfigById(id: string): ServiceConfiguration | undefined {
-    return find(this.configurations, service => service.type.toLowerCase() === id.toLowerCase());
+    return find(this.configurations, service => service.id.toLowerCase() === id.toLowerCase());
   }
 
 }

--- a/packages/core/src/configuration/ConfigurationHelper.ts
+++ b/packages/core/src/configuration/ConfigurationHelper.ts
@@ -17,10 +17,18 @@ export class ConfigurationHelper {
 
   /**
    * Get a service configuration object, provided an existing id is given
-   * @param type string - The type of the service
+   * @param type - The type of the service
    */
   public getConfig(type: string): ServiceConfiguration | undefined {
     return find(this.configurations, service => service.type.toLowerCase() === type.toLowerCase());
+  }
+
+  /**
+   * Get a service configuration object, provided an existing id is given
+   * @param id - unique id of the service
+   */
+  public getConfigById(id: string): ServiceConfiguration | undefined {
+    return find(this.configurations, service => service.type.toLowerCase() === id.toLowerCase());
   }
 
 }

--- a/packages/core/src/metrics/MetricsService.ts
+++ b/packages/core/src/metrics/MetricsService.ts
@@ -22,12 +22,12 @@ export class MetricsService {
   private readonly defaultMetrics: Metrics[];
 
   constructor(appConfig: AeroGearConfiguration) {
-    const configuration = new ConfigurationHelper(appConfig).getConfig(MetricsService.ID);
+    const configuration = new ConfigurationHelper(appConfig).getConfigByType(MetricsService.ID);
     this.defaultMetrics = this.buildDefaultMetrics();
 
-    if (configuration) {
-      this.configuration = configuration;
-      this.publisher = new NetworkMetricsPublisher(configuration.url);
+    if (configuration && configuration.length > 0) {
+      this.configuration = configuration[0];
+      this.publisher = new NetworkMetricsPublisher(this.configuration.url);
       this.sendInitialAppAndDeviceMetrics();
     } else {
       console.warn("Metrics configuration is missing. Metrics will not be published to remote server.");

--- a/packages/core/src/metrics/MetricsService.ts
+++ b/packages/core/src/metrics/MetricsService.ts
@@ -15,14 +15,14 @@ export class MetricsService {
 
   public static readonly CLIENT_ID_KEY = "aerogear_metrics_client_key";
   public static readonly DEFAULT_METRICS_TYPE = "init";
-  public static readonly ID = "metrics";
+  public static readonly TYPE = "metrics";
 
   protected publisher?: MetricsPublisher;
   protected configuration?: ServiceConfiguration;
   private readonly defaultMetrics: Metrics[];
 
   constructor(appConfig: AeroGearConfiguration) {
-    const configuration = new ConfigurationHelper(appConfig).getConfigByType(MetricsService.ID);
+    const configuration = new ConfigurationHelper(appConfig).getConfigByType(MetricsService.TYPE);
     this.defaultMetrics = this.buildDefaultMetrics();
 
     if (configuration && configuration.length > 0) {

--- a/packages/core/test/configuration/ConfigurationParser.ts
+++ b/packages/core/test/configuration/ConfigurationParser.ts
@@ -43,15 +43,15 @@ describe("ConfigurationParser", () => {
   describe("#getConfig", () => {
 
     it("should return undefined if using an nonexistent key", () => {
-      const result = parser.getConfig("foo");
+      const result = parser.getConfigByType("foo");
 
-      assert.isUndefined(result);
+      assert.isArray(result);
+      assert.isOk(result.length === 0);
     });
 
     it("should be able to get config if its key exists", () => {
-      const result = parser.getConfig("keycloak");
-
-      expect(result.type).to.equal("keycloak");
+      const result = parser.getConfigByType("keycloak");
+      expect(result[0].type).to.equal("keycloak");
     });
 
   });

--- a/packages/core/test/metrics/MetricsService.ts
+++ b/packages/core/test/metrics/MetricsService.ts
@@ -14,7 +14,7 @@ import testAerogearConfig from "../mobile-config.json";
 
 describe("MetricsService", () => {
 
-  const metricsConfig = new ConfigurationHelper(testAerogearConfig).getConfig(MetricsService.ID);
+  const metricsConfig = new ConfigurationHelper(testAerogearConfig).getConfigByType(MetricsService.ID)[0];
   const storage = { clientId: null };
 
   let metricsService: MetricsService;

--- a/packages/core/test/metrics/MetricsService.ts
+++ b/packages/core/test/metrics/MetricsService.ts
@@ -14,7 +14,7 @@ import testAerogearConfig from "../mobile-config.json";
 
 describe("MetricsService", () => {
 
-  const metricsConfig = new ConfigurationHelper(testAerogearConfig).getConfigByType(MetricsService.ID)[0];
+  const metricsConfig = new ConfigurationHelper(testAerogearConfig).getConfigByType(MetricsService.TYPE)[0];
   const storage = { clientId: null };
 
   let metricsService: MetricsService;


### PR DESCRIPTION
## Motivation

Use type for fetching mobile configurations instead of name.
Name is just human readable name and it's not guaranteed to be unique.

See: https://github.com/aerogear/aerogear-android-sdk/pull/217