### PR TITLE
AEROGEAR-2672 Implement debug security check

### DIFF
--- a/packages/security-cordova/plugin.xml
+++ b/packages/security-cordova/plugin.xml
@@ -8,6 +8,10 @@
     <name>cordova-plugin-aerogear-security</name>
 
     <dependency id="cordova-plugin-iroot" version="0.7.0" />
+
     <dependency id="cordova-plugin-device" version="2.0.2" />
+
+    <dependency id="cordova-plugin-is-debug" version="^1.0.0" />
+
 
 </plugin>

--- a/packages/security/src/deviceTrust/SecurityCheckType.ts
+++ b/packages/security/src/deviceTrust/SecurityCheckType.ts
@@ -1,4 +1,4 @@
-import { NonEmulatedCheck, NonRootedCheck, NonDebugCheck } from "./checks";
+import { NonDebugCheck, NonEmulatedCheck, NonRootedCheck } from "./checks";
 
 /**
  * Detect whether a device is rooted (Android) or Jailbroken (iOS).
@@ -12,6 +12,3 @@ export const notEmulated = new NonEmulatedCheck();
    * Detect whether a device is running in debug mode.
    */
 export const notDebugMode = new NonDebugCheck();
-
-
-

--- a/packages/security/src/deviceTrust/SecurityCheckType.ts
+++ b/packages/security/src/deviceTrust/SecurityCheckType.ts
@@ -1,4 +1,4 @@
-import { NonEmulatedCheck, NonRootedCheck } from "./checks";
+import { NonEmulatedCheck, NonRootedCheck, DebuggerCheck } from "./checks";
 
 /**
  * Detect whether a device is rooted (Android) or Jailbroken (iOS).
@@ -8,3 +8,5 @@ export const notRooted = new NonRootedCheck();
  * Detect whether a device is running on an emulator
  */
 export const notEmulated = new NonEmulatedCheck();
+
+export const notDebugger = new DebuggerCheck();

--- a/packages/security/src/deviceTrust/SecurityCheckType.ts
+++ b/packages/security/src/deviceTrust/SecurityCheckType.ts
@@ -1,4 +1,4 @@
-import { NonEmulatedCheck, NonRootedCheck, DebuggerCheck } from "./checks";
+import { NonEmulatedCheck, NonRootedCheck, NonDebugCheck } from "./checks";
 
 /**
  * Detect whether a device is rooted (Android) or Jailbroken (iOS).
@@ -9,9 +9,9 @@ export const notRooted = new NonRootedCheck();
  */
 export const notEmulated = new NonEmulatedCheck();
   /**
-   * A check for whether a debugger is attached to the current application
+   * Detect whether a device is running in debug mode.
    */
-export const IsDebuggerConnected = new DebuggerCheck();
+export const notDebugMode = new NonDebugCheck();
 
 
 

--- a/packages/security/src/deviceTrust/SecurityCheckType.ts
+++ b/packages/security/src/deviceTrust/SecurityCheckType.ts
@@ -8,5 +8,10 @@ export const notRooted = new NonRootedCheck();
  * Detect whether a device is running on an emulator
  */
 export const notEmulated = new NonEmulatedCheck();
+  /**
+   * A check for whether a debugger is attached to the current application
+   */
+export const IsDebuggerConnected = new DebuggerCheck();
 
-export const notDebugger = new DebuggerCheck();
+
+

--- a/packages/security/src/deviceTrust/checks/DebuggerCheck.ts
+++ b/packages/security/src/deviceTrust/checks/DebuggerCheck.ts
@@ -3,18 +3,24 @@ import { SecurityCheckResult } from "../SecurityCheckResult";
 
 declare let cordova: any;
 
+/**
+ * A check for whether a debugger is attached to the current application
+ */
 export class DebuggerCheck implements SecurityCheck {
     public readonly name = "Is Debugger Check";
 
+    /**
+     * An application running with an attached debugger can have its internals exposed.
+     */
     public check(): Promise<SecurityCheckResult> {
         return new Promise((resolve, reject) => {
-            if (!cordova.plugins.isDebug) {
+            if (!cordova.plugins.IsDebug) {
                 reject(new Error("Could not find plugin isDebug."));
                 return;
             }
 
-            cordova.plugins.isDebug((passed: boolean) => {
-                const result: SecurityCheckResult = {name: this.name, passed};
+            cordova.plugins.IsDebug.getIsDebug((passed: boolean) => {
+                const result: SecurityCheckResult = {name: this.name, passed: !passed};
                 return resolve(result);
             }, (error: string) => reject(error));
         });

--- a/packages/security/src/deviceTrust/checks/DebuggerCheck.ts
+++ b/packages/security/src/deviceTrust/checks/DebuggerCheck.ts
@@ -1,0 +1,22 @@
+import { SecurityCheck } from "../SecurityCheck";
+import { SecurityCheckResult } from "../SecurityCheckResult";
+
+declare let cordova: any;
+
+export class DebuggerCheck implements SecurityCheck{
+    public readonly name = "Is Debugger Check";
+
+    public check(): Promise<SecurityCheckResult> {
+        return new Promise((resolve, reject) => {
+            if(!cordova.plugins.isDebug){
+                reject(new Error("Could not find plugin isDebug."));
+                return;
+            }
+
+            cordova.plugins.isDebug((passed: boolean) => {
+                const result: SecurityCheckResult = {name: this.name,passed:  passed};
+                return resolve(result);
+            }, (error: string) => reject(error));
+        })
+    }
+}

--- a/packages/security/src/deviceTrust/checks/DebuggerCheck.ts
+++ b/packages/security/src/deviceTrust/checks/DebuggerCheck.ts
@@ -3,20 +3,20 @@ import { SecurityCheckResult } from "../SecurityCheckResult";
 
 declare let cordova: any;
 
-export class DebuggerCheck implements SecurityCheck{
+export class DebuggerCheck implements SecurityCheck {
     public readonly name = "Is Debugger Check";
 
     public check(): Promise<SecurityCheckResult> {
         return new Promise((resolve, reject) => {
-            if(!cordova.plugins.isDebug){
+            if (!cordova.plugins.isDebug) {
                 reject(new Error("Could not find plugin isDebug."));
                 return;
             }
 
             cordova.plugins.isDebug((passed: boolean) => {
-                const result: SecurityCheckResult = {name: this.name,passed:  passed};
+                const result: SecurityCheckResult = {name: this.name, passed};
                 return resolve(result);
             }, (error: string) => reject(error));
-        })
+        });
     }
 }

--- a/packages/security/src/deviceTrust/checks/NonDebugCheck.ts
+++ b/packages/security/src/deviceTrust/checks/NonDebugCheck.ts
@@ -6,7 +6,7 @@ declare let cordova: any;
 /**
  * A check for whether a debugger is attached to the current application
  */
-export class DebuggerCheck implements SecurityCheck {
+export class NonDebugCheck implements SecurityCheck {
     public readonly name = "Is Debugger Check";
 
     /**
@@ -14,7 +14,7 @@ export class DebuggerCheck implements SecurityCheck {
      */
     public check(): Promise<SecurityCheckResult> {
         return new Promise((resolve, reject) => {
-            if (!cordova.plugins.IsDebug) {
+            if (!cordova || !cordova.plugins || !cordova.plugins.IsDebug) {
                 reject(new Error("Could not find plugin isDebug."));
                 return;
             }

--- a/packages/security/src/deviceTrust/checks/NonDebugCheck.ts
+++ b/packages/security/src/deviceTrust/checks/NonDebugCheck.ts
@@ -4,14 +4,11 @@ import { SecurityCheckResult } from "../SecurityCheckResult";
 declare let cordova: any;
 
 /**
- * A check for whether a debugger is attached to the current application
+ * A check for whether a device is running in debug mode
  */
 export class NonDebugCheck implements SecurityCheck {
     public readonly name = "Is Debugger Check";
 
-    /**
-     * An application running with an attached debugger can have its internals exposed.
-     */
     public check(): Promise<SecurityCheckResult> {
         return new Promise((resolve, reject) => {
             if (!cordova || !cordova.plugins || !cordova.plugins.IsDebug) {

--- a/packages/security/src/deviceTrust/checks/index.ts
+++ b/packages/security/src/deviceTrust/checks/index.ts
@@ -2,4 +2,3 @@
 export { NonRootedCheck } from "./NonRootedCheck";
 export { NonEmulatedCheck } from "./NonEmulatedCheck";
 export { NonDebugCheck } from "./NonDebugCheck";
-

--- a/packages/security/src/deviceTrust/checks/index.ts
+++ b/packages/security/src/deviceTrust/checks/index.ts
@@ -1,5 +1,5 @@
 
 export { NonRootedCheck } from "./NonRootedCheck";
 export { NonEmulatedCheck } from "./NonEmulatedCheck";
-export { DebuggerCheck } from "./DebuggerCheck";
+export { NonDebugCheck } from "./NonDebugCheck";
 

--- a/packages/security/src/deviceTrust/checks/index.ts
+++ b/packages/security/src/deviceTrust/checks/index.ts
@@ -1,2 +1,5 @@
+
 export { NonRootedCheck } from "./NonRootedCheck";
 export { NonEmulatedCheck } from "./NonEmulatedCheck";
+export { DebuggerCheck } from "./DebuggerCheck";
+


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-2676

## Description
Currently, we do not have a check to see if a device is running in debug mode. This PR adds a debug check by using a cordova plugin which is added to our aerogear security plugin

## Verify
The following PR can be used to verify these changes: https://github.com/aerogear/cordova-showcase-template/pull/29

In SDK root folder run:
```
npm install
npm run bootstrap
npm run build
```
cd to `cordova-showcase` and checkout above PR and run the following:
```
cordova plugin add --link <<path to security-cordova>>
npm install
npm run ionic:<<ios or android>>
```
