### PR TITLE
Add documentation and refactor check type

### DIFF
--- a/packages/security/src/SecurityService.ts
+++ b/packages/security/src/SecurityService.ts
@@ -1,6 +1,15 @@
 import { SecurityCheck, SecurityCheckResult } from "./deviceTrust";
 
+/**
+ * Service module for handling performing and reporting checks.
+ */
 export class SecurityService {
+
+  /**
+   * Execute the provided security check and return the result.
+   *
+   * @returns {Promise<SecurityCheckResult>}
+   */
   public check(check: SecurityCheck): Promise<SecurityCheckResult> {
     return check.check();
   }

--- a/packages/security/src/SecurityService.ts
+++ b/packages/security/src/SecurityService.ts
@@ -1,14 +1,18 @@
 import { SecurityCheck, SecurityCheckResult } from "./deviceTrust";
 
 /**
- * Service module for handling performing and reporting checks.
+ * Service module for handling performing and reporting  possible security
+ * issues in a mobile application.
+ *
+ * This requires the @aerogear/cordova-plugin-aerogear-security plugin to be
+ * included in an application.
  */
 export class SecurityService {
 
   /**
    * Execute the provided security check and return the result.
    *
-   * @returns {Promise<SecurityCheckResult>}
+   * @returns The result of the provided check.
    */
   public check(check: SecurityCheck): Promise<SecurityCheckResult> {
     return check.check();

--- a/packages/security/src/deviceTrust/SecurityCheck.ts
+++ b/packages/security/src/deviceTrust/SecurityCheck.ts
@@ -1,7 +1,7 @@
 import { SecurityCheckResult } from "./SecurityCheckResult";
 
 /**
- * Interface for a device security single check that can be executed.
+ * Interface for a device security single security check that can be executed.
  */
 export interface SecurityCheck {
   /**
@@ -10,9 +10,9 @@ export interface SecurityCheck {
   name: string;
 
   /**
-   * Execute the check.
+   * Execute the security check.
    *
-   * @returns {Promise<SecurityCheckResult>}
+   * @returns The result of the check.
    */
   check(): Promise<SecurityCheckResult>;
 }

--- a/packages/security/src/deviceTrust/SecurityCheck.ts
+++ b/packages/security/src/deviceTrust/SecurityCheck.ts
@@ -1,7 +1,18 @@
 import { SecurityCheckResult } from "./SecurityCheckResult";
 
+/**
+ * Interface for a device security single check that can be executed.
+ */
 export interface SecurityCheck {
+  /**
+   * The name of the check. This can be used for reporting the checks results.
+   */
   name: string;
 
+  /**
+   * Execute the check.
+   *
+   * @returns {Promise<SecurityCheckResult>}
+   */
   check(): Promise<SecurityCheckResult>;
 }

--- a/packages/security/src/deviceTrust/SecurityCheckResult.ts
+++ b/packages/security/src/deviceTrust/SecurityCheckResult.ts
@@ -8,12 +8,7 @@ export interface SecurityCheckResult {
   name: string;
 
   /**
-   * Whether the check passed or failed. A successful check means that the environment this
-   * application is running in is more secure than otherwise, as opposed to signalling if a
-   * certain feature was enabled
-   *
-   * For example, a check for whether the device is Rooted should return true when it
-   * is *not* rooted, since this would be the more secure condition.
+   * If the executed check completed with success or failure.
    */
   passed: boolean;
 }

--- a/packages/security/src/deviceTrust/SecurityCheckResult.ts
+++ b/packages/security/src/deviceTrust/SecurityCheckResult.ts
@@ -1,4 +1,19 @@
+/**
+ * Interface for the results of a single pass/fail security check.
+ */
 export interface SecurityCheckResult {
+  /**
+   * The name of the check. This can be used for reporting the check results.
+   */
   name: string;
+
+  /**
+   * Whether the check passed or failed. A successful check means that the environment this
+   * application is running in is more secure than otherwise, as opposed to signalling if a
+   * certain feature was enabled
+   *
+   * For example, a check for whether the device is Rooted should return true when it
+   * is *not* rooted, since this would be the more secure condition.
+   */
   passed: boolean;
 }

--- a/packages/security/src/deviceTrust/SecurityCheckType.ts
+++ b/packages/security/src/deviceTrust/SecurityCheckType.ts
@@ -1,7 +1,6 @@
 import { RootedCheck } from "./checks";
 
-export class SecurityCheckType {
-  public static readonly IsRooted = new RootedCheck();
-
-  private constructor() {}
-}
+/**
+ * Detect whether a device is rooted (Android) or Jailbroken (iOS).
+ */
+export const isRooted = new RootedCheck();

--- a/packages/security/src/deviceTrust/SecurityCheckType.ts
+++ b/packages/security/src/deviceTrust/SecurityCheckType.ts
@@ -1,6 +1,6 @@
-import { RootedCheck } from "./checks";
+import { NonRootedCheck } from "./checks";
 
 /**
  * Detect whether a device is rooted (Android) or Jailbroken (iOS).
  */
-export const isRooted = new RootedCheck();
+export const notRooted = new NonRootedCheck();

--- a/packages/security/src/deviceTrust/checks/NonRootedCheck.ts
+++ b/packages/security/src/deviceTrust/checks/NonRootedCheck.ts
@@ -6,7 +6,7 @@ declare var IRoot: any;
 /**
  * Check to detect whether a device is rooted (Android) or jailbroken (iOS).
  */
-export class RootedCheck implements SecurityCheck {
+export class NonRootedCheck implements SecurityCheck {
   /**
    * Get the name of the check.
    */
@@ -16,9 +16,9 @@ export class RootedCheck implements SecurityCheck {
 
   /**
    * Determine whether the device is rooted (Android) or jailbroken (iOS).
-   * If the device is not rooted/jailbroken then the check will pass.
+   * If the device is *not* rooted/jailbroken then the check will pass.
    *
-   * @returns {Promise<SecurityCheckResult>}
+   * @returns The result of the check.
    */
   public check(): Promise<SecurityCheckResult> {
     return new Promise((resolve, reject) => {
@@ -28,7 +28,7 @@ export class RootedCheck implements SecurityCheck {
       }
 
       IRoot.isRooted((rooted: number) => {
-        const result: SecurityCheckResult = { name: this.name, passed: !!rooted};
+        const result: SecurityCheckResult = { name: this.name, passed: !rooted};
         return resolve(result);
       }, (error: string) => reject(error));
     });

--- a/packages/security/src/deviceTrust/checks/RootedCheck.ts
+++ b/packages/security/src/deviceTrust/checks/RootedCheck.ts
@@ -3,9 +3,23 @@ import { SecurityCheckResult } from "../SecurityCheckResult";
 
 declare var IRoot: any;
 
+/**
+ * Check to detect whether a device is rooted (Android) or jailbroken (iOS).
+ */
 export class RootedCheck implements SecurityCheck {
-  public readonly name = "Rooted Check";
+  /**
+   * Get the name of the check.
+   */
+  get name(): string {
+    return "Rooted Check";
+  }
 
+  /**
+   * Determine whether the device is rooted (Android) or jailbroken (iOS).
+   * If the device is not rooted/jailbroken then the check will pass.
+   *
+   * @returns {Promise<SecurityCheckResult>}
+   */
   public check(): Promise<SecurityCheckResult> {
     return new Promise((resolve, reject) => {
       if (!IRoot) {

--- a/packages/security/src/deviceTrust/checks/index.ts
+++ b/packages/security/src/deviceTrust/checks/index.ts
@@ -1,1 +1,1 @@
-export { RootedCheck } from "./RootedCheck";
+export { NonRootedCheck } from "./NonRootedCheck";

--- a/packages/security/src/deviceTrust/index.ts
+++ b/packages/security/src/deviceTrust/index.ts
@@ -1,4 +1,6 @@
+import * as SecurityCheckType from "./SecurityCheckType";
+
 export { SecurityCheck } from "./SecurityCheck";
-export { SecurityCheckType } from "./SecurityCheckType";
+export { SecurityCheckType };
 export { SecurityCheckResult } from "./SecurityCheckResult";
 export * from "./checks";


### PR DESCRIPTION
## Motivation

Currently there is no API documentation for the security service.

## Description
Add API documentation for the security service.

There is also a small refactor of the `SecurityCheckType` module.

## Progress
- [x] API docs
- [x] Refactor SecurityCheckType
- [x] Make isRooted check consistent with the Android SDK implementation.
