### PR TITLE
AEROGEAR-2687 Allow for multiple checks to be performed

### DIFF
--- a/packages/security/src/SecurityService.ts
+++ b/packages/security/src/SecurityService.ts
@@ -12,9 +12,18 @@ export class SecurityService {
   /**
    * Execute the provided security check and return the result.
    *
-   * @returns The result of the provided check.
+   * @returns A result for the security check provided.
    */
   public check(check: SecurityCheck): Promise<SecurityCheckResult> {
     return check.check();
+  }
+
+  /**
+   * Execute the provided security checks and return the results in an array.
+   *
+   * @returns An array of results for the provided checks.
+   */
+  public checkMany(...checks: SecurityCheck): Promise<SecurityCheckResult[]> {
+    return Promise.all(checks.map(check => check.check()));
   }
 }

--- a/packages/security/test/SecurityService.ts
+++ b/packages/security/test/SecurityService.ts
@@ -13,7 +13,6 @@ describe("SecurityService", () => {
   });
 
   describe("#check", () => {
-
     it("should pass if the provided check passes", async () => {
       const mockCheck = new MockCheck(true);
       const result = await securityService.check(mockCheck);
@@ -25,5 +24,19 @@ describe("SecurityService", () => {
       const result = await securityService.check(new MockCheck(false));
       assert.isFalse(result.passed);
     });
- });
+  });
+
+  describe("#checkMany", () => {
+    it("should allow for no arguments", async () => {
+      const results = await securityService.checkMany();
+      expect(results.length).to.equal(0);
+    });
+
+    it("should run multiple checks", async () => {
+      const results = await securityService.checkMany(new MockCheck(true), new MockCheck(false));
+      expect(results.length).to.equal(2);
+      assert(results[0].passed);
+      assert.isFalse(results[1].passed);
+    });
+  });
 });


### PR DESCRIPTION
## Motivation

Currently the SecurityService can only perform single checks.

## Description
Allow for multiple checks to be passed to a `checkMany` function.

## Progress
- [x] Implementation
- [x] Unit tests
- [x] Documentation
