### PR TITLE
AEROGEAR-2677 Device lock security check

### DIFF
--- a/docs/security/security.adoc
+++ b/docs/security/security.adoc
@@ -66,6 +66,7 @@ To detect if the app is runing in debug mode the `notDebugMode` function can be 
 
 To detect if a device has a lock screen set the `hasDeviceLock` function can be used. If the device *has* a screen lock enabled then this check will pass.
 
+NOTE: For iOS devices this check requires iOS 8 or above.
 
 === Invoking a Single Self Defence Check
 

--- a/packages/security-cordova/plugin.xml
+++ b/packages/security-cordova/plugin.xml
@@ -13,5 +13,5 @@
 
     <dependency id="cordova-plugin-is-debug" version="^1.0.0" />
 
-
+    <dependency id="cordova-plugin-pincheck" version="0.0.5" />
 </plugin>

--- a/packages/security/src/deviceTrust/SecurityCheckType.ts
+++ b/packages/security/src/deviceTrust/SecurityCheckType.ts
@@ -1,4 +1,4 @@
-import { NonDebugCheck, NonEmulatedCheck, NonRootedCheck } from "./checks";
+import { DeviceLockCheck, NonDebugCheck, NonEmulatedCheck, NonRootedCheck } from "./checks";
 
 /**
  * Detect whether a device is rooted (Android) or Jailbroken (iOS).
@@ -12,3 +12,7 @@ export const notEmulated = new NonEmulatedCheck();
    * Detect whether a device is running in debug mode.
    */
 export const notDebugMode = new NonDebugCheck();
+/**
+ * Detect whether a device has a screen lock set or not.
+ */
+export const hasDeviceLock = new DeviceLockCheck();

--- a/packages/security/src/deviceTrust/checks/DeviceLockCheck.ts
+++ b/packages/security/src/deviceTrust/checks/DeviceLockCheck.ts
@@ -2,6 +2,7 @@ import { SecurityCheck } from "../SecurityCheck";
 import { SecurityCheckResult } from "../SecurityCheckResult";
 
 declare var cordova: any;
+declare var document: any;
 
 /**
  * Security check to detect if a device has a screen lock set or not.
@@ -23,21 +24,27 @@ export class DeviceLockCheck implements SecurityCheck {
    */
   public check(): Promise<SecurityCheckResult> {
     return new Promise((resolve, reject) => {
-      if (!cordova || !cordova.plugins || !cordova.plugins.PinCheck) {
-        reject(new Error("Could not find plugin PinCheck"));
+      if (!document) {
+        reject(new Error("Cordova not fully loaded"));
       }
 
-      cordova.plugins.PinCheck.isPinSetup((pinIsSet: string) => {
-        const result: SecurityCheckResult = { name: this.name, passed: !!pinIsSet };
-        return resolve(result);
-      }, (error: Error) => {
-        if (error.toString() === "NO_PIN_SETUP") {
-          const result: SecurityCheckResult = { name: this.name, passed: !error };
-          return resolve(result);
-        } else {
-          return reject(error);
+      document.addEventListener("deviceready", () => {
+        if (!cordova || !cordova.plugins || !cordova.plugins.PinCheck) {
+          reject(new Error("Could not find plugin PinCheck"));
         }
-      });
+
+        cordova.plugins.PinCheck.isPinSetup((pinIsSet: string) => {
+          const result: SecurityCheckResult = { name: this.name, passed: !!pinIsSet };
+          return resolve(result);
+        }, (error: Error) => {
+          if (error.toString() === "NO_PIN_SETUP") {
+            const result: SecurityCheckResult = { name: this.name, passed: !error };
+            return resolve(result);
+          } else {
+            return reject(error);
+          }
+        });
+      }, false);
     });
   }
 }

--- a/packages/security/src/deviceTrust/checks/DeviceLockCheck.ts
+++ b/packages/security/src/deviceTrust/checks/DeviceLockCheck.ts
@@ -1,0 +1,43 @@
+import { SecurityCheck } from "../SecurityCheck";
+import { SecurityCheckResult } from "../SecurityCheckResult";
+
+declare var cordova: any;
+
+/**
+ * Security check to detect if a device has a screen lock set or not.
+ */
+export class DeviceLockCheck implements SecurityCheck {
+  /**
+   * Get the name of the check.
+   */
+  get name(): string {
+    return "Device Lock Check";
+  }
+
+  /**
+   * Determine whether a device has a screen lock set or not.
+   * If the device *has* a screen lock set then the check
+   * will pass.
+   *
+   * @returns The result of the check.
+   */
+  public check(): Promise<SecurityCheckResult> {
+    return new Promise((resolve, reject) => {
+      if (!cordova || !cordova.plugins || !cordova.plugins.PinCheck) {
+        reject(new Error("Could not find plugin PinCheck"));
+      }
+
+      cordova.plugins.PinCheck.isPinSetup((pinIsSet: string) => {
+        const result: SecurityCheckResult = { name: this.name, passed: !!pinIsSet };
+        return resolve(result);
+      }, (error: Error) => {
+        if (error.toString() === "NO_PIN_SETUP") {
+          const result: SecurityCheckResult = { name: this.name, passed: !error };
+          return resolve(result);
+        } else {
+          return reject(error);
+        }
+      });
+    });
+  }
+}

--- a/packages/security/src/deviceTrust/checks/DeviceLockCheck.ts
+++ b/packages/security/src/deviceTrust/checks/DeviceLockCheck.ts
@@ -33,17 +33,8 @@ export class DeviceLockCheck implements SecurityCheck {
           reject(new Error("Could not find plugin PinCheck"));
         }
 
-        cordova.plugins.PinCheck.isPinSetup((pinIsSet: string) => {
-          const result: SecurityCheckResult = { name: this.name, passed: !!pinIsSet };
-          return resolve(result);
-        }, (error: Error) => {
-          if (error.toString() === "NO_PIN_SETUP") {
-            const result: SecurityCheckResult = { name: this.name, passed: !error };
-            return resolve(result);
-          } else {
-            return reject(error);
-          }
-        });
+        cordova.plugins.PinCheck.isPinSetup(() => resolve({ name: this.name, passed: true }),
+          () => resolve({ name: this.name, passed: false }));
       }, false);
     });
   }

--- a/packages/security/src/deviceTrust/checks/NonDebugCheck.ts
+++ b/packages/security/src/deviceTrust/checks/NonDebugCheck.ts
@@ -2,24 +2,35 @@ import { SecurityCheck } from "../SecurityCheck";
 import { SecurityCheckResult } from "../SecurityCheckResult";
 
 declare let cordova: any;
+declare var document: any;
 
 /**
  * A check for whether a device is running in debug mode
  */
 export class NonDebugCheck implements SecurityCheck {
-    public readonly name = "Is Debugger Check";
-
+    /**
+     * Get the name of the check.
+     */
+    get name(): string {
+        return "Debugger Check";
+    }
     public check(): Promise<SecurityCheckResult> {
         return new Promise((resolve, reject) => {
-            if (!cordova || !cordova.plugins || !cordova.plugins.IsDebug) {
-                reject(new Error("Could not find plugin isDebug."));
-                return;
+            if (!document) {
+                reject(new Error("Cordova not fully loaded"));
             }
 
-            cordova.plugins.IsDebug.getIsDebug((passed: boolean) => {
-                const result: SecurityCheckResult = {name: this.name, passed: !passed};
-                return resolve(result);
-            }, (error: string) => reject(error));
+            document.addEventListener("deviceready", () => {
+                if (!cordova || !cordova.plugins || !cordova.plugins.IsDebug) {
+                    reject(new Error("Could not find plugin isDebug."));
+                    return;
+                }
+
+                cordova.plugins.IsDebug.getIsDebug((passed: boolean) => {
+                    const result: SecurityCheckResult = { name: this.name, passed: !passed };
+                    return resolve(result);
+                }, (error: string) => reject(error));
+            }, false);
         });
     }
 }

--- a/packages/security/src/deviceTrust/checks/NonEmulatedCheck.ts
+++ b/packages/security/src/deviceTrust/checks/NonEmulatedCheck.ts
@@ -2,6 +2,7 @@ import { SecurityCheck } from "../SecurityCheck";
 import { SecurityCheckResult } from "../SecurityCheckResult";
 
 declare var device: any;
+declare var document: any;
 
 /**
  * Security check to detect if a device is running in an emulator.
@@ -22,12 +23,18 @@ export class NonEmulatedCheck implements SecurityCheck {
    */
   public check(): Promise<SecurityCheckResult> {
     return new Promise((resolve, reject) => {
-      if (!device) {
-        reject(new Error("Could not find plugin device."));
-        return;
+      if (!document) {
+        reject(new Error("Cordova not fully loaded"));
       }
-      const result: SecurityCheckResult = { name: this.name, passed: !device.isVirtual };
-      return resolve(result);
+
+      document.addEventListener("deviceready", () => {
+        if (!device) {
+          reject(new Error("Could not find plugin device."));
+          return;
+        }
+        const result: SecurityCheckResult = { name: this.name, passed: !device.isVirtual };
+        return resolve(result);
+      }, false);
     });
   }
 }

--- a/packages/security/src/deviceTrust/checks/NonRootedCheck.ts
+++ b/packages/security/src/deviceTrust/checks/NonRootedCheck.ts
@@ -2,6 +2,7 @@ import { SecurityCheck } from "../SecurityCheck";
 import { SecurityCheckResult } from "../SecurityCheckResult";
 
 declare var IRoot: any;
+declare var document: any;
 
 /**
  * Check to detect whether a device is rooted (Android) or jailbroken (iOS).
@@ -22,15 +23,21 @@ export class NonRootedCheck implements SecurityCheck {
    */
   public check(): Promise<SecurityCheckResult> {
     return new Promise((resolve, reject) => {
-      if (!IRoot) {
-        reject(new Error("Could not find plugin IRoot."));
-        return;
+      if (!document) {
+        reject(new Error("Cordova not fully loaded"));
       }
 
-      IRoot.isRooted((rooted: number) => {
-        const result: SecurityCheckResult = { name: this.name, passed: !rooted};
-        return resolve(result);
-      }, (error: string) => reject(error));
+      document.addEventListener("deviceready", () => {
+        if (!IRoot) {
+          reject(new Error("Could not find plugin IRoot."));
+          return;
+        }
+
+        IRoot.isRooted((rooted: number) => {
+          const result: SecurityCheckResult = { name: this.name, passed: !rooted };
+          return resolve(result);
+        }, (error: string) => reject(error));
+      }, false);
     });
   }
 }

--- a/packages/security/src/deviceTrust/checks/index.ts
+++ b/packages/security/src/deviceTrust/checks/index.ts
@@ -2,3 +2,4 @@
 export { NonRootedCheck } from "./NonRootedCheck";
 export { NonEmulatedCheck } from "./NonEmulatedCheck";
 export { NonDebugCheck } from "./NonDebugCheck";
+export { DeviceLockCheck } from "./DeviceLockCheck";


### PR DESCRIPTION
## Motivation

JIRA: https://issues.jboss.org/browse/AEROGEAR-2677

This is intended to replace #87

## Description
Added security check to check if the device lock is set or not.

Simplify the check performed in #87 based on the description and reading the code or https://github.com/shangyilim/cordova-plugin-pincheck. This also resolves an issue with iOS failure on a device.

## Verification steps

#### Android
* Run https://github.com/aerogear/cordova-showcase-template/tree/AEROGEAR-2526-security-checks (device or emulator).
* Ensure the check passes when a lock is set
* Ensure the check fails when a lock isn't set

#### iOS
* Run https://github.com/aerogear/cordova-showcase-template/tree/AEROGEAR-2526-security-checks (device only)
* Ensure the check passes when a lock is set
* Ensure the check fails when a lock isn't set