### PR TITLE
fix: add script and docs for link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to the AeroGear Web SDK
+# Contributing to the AeroGear JS SDK
 
 The AeroGear Web SDK is part of the [AeroGear project](https://aerogear.org/), see the [Community Page](https://aerogear.org/community) for general guidelines for contributing to the project.
 

--- a/docs/contrib/contributing-guide.adoc
+++ b/docs/contrib/contributing-guide.adoc
@@ -47,3 +47,16 @@ Finally, add the following link:../templates/tsconfig.json[`tsconfig.json`].
 == Publishing a module
 
 Please refer to the https://github.com/aerogear/aerogear-js-sdk/blob/master/docs/releng.adoc[Release Docs].
+
+== Showcase App
+
+Testing can be done using showcase application:
+
+https://github.com/aerogear/cordova-showcase-template
+
+Please follow showcase application contribution guide for instructions.
+To make sure that showcase application links the right source code please execute following commands.
+
+[source,bash]
+npm run build
+npm run link

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "updateXml": "lerna exec -- \\$LERNA_ROOT_PATH/scripts/updatePluginXmlVersion.sh",
     "publish:canary": "lerna publish --canary",
     "publish": "lerna exec npm publish",
+    "link": "lerna exec npm link .",
     "clean": "npm-run-all clean:*",
     "clean:packages": "lerna run clean",
     "clean:dependencies": "lerna clean --yes",


### PR DESCRIPTION
## Motivation

New version of lerna no longer using npm link. 
This means that to use modules outside (in showcase app ) we need to link them manually. @TommyJ1994 Hit issue when link was pointing to different source code. This PR resolves that.

Pinging various people just for information about new workflow in repo.
@aidenkeating @ciaranRoche @StephenCoady @TommyJ1994 @wei-lee 


## Verification

```
npm run link
```