### PR TITLE
mention custom security checks in package offers section

### DIFF
--- a/docs/modules/getting-started/pages/security.adoc
+++ b/docs/modules/getting-started/pages/security.adoc
@@ -5,8 +5,9 @@ AeroGear JavaScript SDK offers a set of security features that will make sure th
 This package offers:
 
 1. A suite of self-defence checks to detect a insecure or hostile environment.
-2. Integration with the AeroGear Services Metrics SDK to report self-defence checks data.
+2. Ability to implement custom self-defence checks.
 3. Callbacks to access the results of self-defence checks and take appropriate action in application code.
+4. Integration with the AeroGear Services Metrics SDK to report self-defence checks data.
 
 === Installation
 


### PR DESCRIPTION
## Motivation

Try to keep docs consistent across the SDKS

## Description
Small update to mention the custom self defence checks in the **package offers** section of the security doc.

This was added in the iOS SDK [here](https://github.com/aerogear/aerogear-ios-sdk/pull/111/commits/a018e256ed6eb734ce781cf43f577fecf728e5cc)

## Progress
- [x] Documentation