### PR TITLE
Remove peer dependency in security

### DIFF
--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -25,9 +25,6 @@
     "url": "https://github.com/aerogear/aerogear-js-sdk/issues"
   },
   "homepage": "https://github.com/aerogear/aerogear-js-sdk#readme",
-  "peerDependencies": {
-    "@aerogear/core": "0.2.1"
-  },
   "devDependencies": {
     "@types/chai": "^4.1.3",
     "chai": "^4.1.2",


### PR DESCRIPTION
## Description
The peerDependency is outdated so that the installation throws a warning. Plus also a standard dependency is redundantly included.

The peerDependency is no needed because app package includes core, and app is always required. Packages are not installed twice.


