### PR TITLE
ci: fix git tag validation regex

### DIFF
--- a/scripts/validateRelease.sh
+++ b/scripts/validateRelease.sh
@@ -2,7 +2,7 @@
 
 # explicit declaration that this script needs a $TAG variable passed in e.g TAG=1.2.3 ./script.sh
 TAG=$TAG
-TAG_SYNTAX='[0-9]+\.[0-9]+\.[0-9]+(-.+)*$'
+TAG_SYNTAX='^[0-9]+\.[0-9]+\.[0-9]+(-.+)*$'
 
 # get version found in lerna.json. This is the source of truth
 PACKAGE_VERSION=$(cat lerna.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')

--- a/scripts/validateRelease.sh
+++ b/scripts/validateRelease.sh
@@ -2,7 +2,7 @@
 
 # explicit declaration that this script needs a $TAG variable passed in e.g TAG=1.2.3 ./script.sh
 TAG=$TAG
-TAG_SYNTAX='[[:digit:]].[[:digit:]].[[:digit:]]'
+TAG_SYNTAX='[0-9]+\.[0-9]+\.[0-9]+(-.+)*$'
 
 # get version found in lerna.json. This is the source of truth
 PACKAGE_VERSION=$(cat lerna.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')
@@ -11,8 +11,8 @@ PACKAGE_VERSION=$(cat lerna.json | grep version | head -1 | awk -F: '{ print $2 
 PACKAGES=$(lerna --loglevel=silent ls | awk -F ' ' '{print $1}')
 
 # validate tag has format x.y.z
-if [[ ! $TAG =~ $TAG_SYNTAX ]]; then
-  echo "tag $TAG does not have correct syntax x.y.z. exiting..."
+if [[ "$(echo $TAG | grep -E $TAG_SYNTAX)" == "" ]]; then
+  echo "tag $TAG is invalid. Must be in the format x.y.z or x.y.z-SOME_TEXT"
   exit 1
 fi
 


### PR DESCRIPTION
The previous regex was pretty flawed. It was only checking for the occurrence of one digit. e..g `1.2.3` is valid but `10.2.3` is not valid.

