### PR TITLE
security package is depending on old version of core

### DIFF
--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/aerogear/aerogear-js-sdk#readme",
   "peerDependencies": {
-    "@aerogear/core": "0.2.1"
+    "@aerogear/core": "0.3.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.3",


### PR DESCRIPTION
## Motivation

Security package is depending on old version of core

## Description

Updated the package to depend on core@0.3.0

## Progress
- [x] - version bump
- [ ] - release new version of security package
- [ ] - update all the other packages to the same version?

