### PR TITLE
Minor fixes

### DIFF
--- a/packages/core/src/metrics/MetricsService.ts
+++ b/packages/core/src/metrics/MetricsService.ts
@@ -59,11 +59,15 @@ export class MetricsService {
     const { publisher } = this;
 
     if (!publisher || !this.defaultMetrics) {
-      return Promise.reject(new Error("Metrics server configuration is missing. Metrics will be disabled."));
+      let err = new Error("Metrics server configuration is missing. Metrics will be disabled.");
+      console.warn(err)
+      return Promise.reject(err);
     }
 
     if (!isNative()) {
-      return Promise.reject(new Error("Metrics implementation is disabled for browser platform"));
+      let err = new Error("Metrics implementation is disabled for browser platform.");
+      console.warn(err)
+      return Promise.reject(err);
     }
 
     const payload: MetricsPayload = {

--- a/packages/core/src/metrics/MetricsService.ts
+++ b/packages/core/src/metrics/MetricsService.ts
@@ -59,13 +59,11 @@ export class MetricsService {
     const { publisher } = this;
 
     if (!publisher || !this.defaultMetrics) {
-      console.info("Metrics server configuration is missing. Metrics will be disabled.");
-      return Promise.resolve();
+      return Promise.reject(new Error("Metrics server configuration is missing. Metrics will be disabled."));
     }
 
     if (!isNative()) {
-      console.info("Metrics implementation is disabled for browser platform ");
-      return Promise.resolve();
+      return Promise.reject(new Error("Metrics implementation is disabled for browser platform"));
     }
 
     const payload: MetricsPayload = {

--- a/packages/core/src/metrics/MetricsService.ts
+++ b/packages/core/src/metrics/MetricsService.ts
@@ -59,14 +59,14 @@ export class MetricsService {
     const { publisher } = this;
 
     if (!publisher || !this.defaultMetrics) {
-      let err = new Error("Metrics server configuration is missing. Metrics will be disabled.");
-      console.warn(err)
+      const err = new Error("Metrics server configuration is missing. Metrics will be disabled.");
+      console.warn(err);
       return Promise.reject(err);
     }
 
     if (!isNative()) {
-      let err = new Error("Metrics implementation is disabled for browser platform.");
-      console.warn(err)
+      const err = new Error("Metrics implementation is disabled for browser platform.");
+      console.warn(err);
       return Promise.reject(err);
     }
 

--- a/scripts/cloneExamples.sh
+++ b/scripts/cloneExamples.sh
@@ -1,7 +1,7 @@
 set -eo pipefail
 
 echo "Development script that clones example application to be available in the repository"
-git clone git@github.com:aerogear/cordova-showcase-template.git cordova-example-prod
+git clone git@github.com:aerogear/cordova-showcase-template.git cordova-example
 
 cd cordova-example
 npm install


### PR DESCRIPTION
* Metrics SDK was calling `Promise.resolve()` in error situations.
* `cloneExamples.sh` had a typo with some path names.

