### PR TITLE
force platform to lower case in allignment with our other sdks

### DIFF
--- a/packages/core/src/metrics/platform/CordovaDeviceMetrics.ts
+++ b/packages/core/src/metrics/platform/CordovaDeviceMetrics.ts
@@ -26,7 +26,7 @@ export class CordovaDeviceMetrics implements Metrics {
           );
         }
         return resolve({
-          platform: window.device.platform,
+          platform: window.device.platform.toLowerCase(),
           platformVersion: window.device.version,
           device: window.device.model
         });


### PR DESCRIPTION
## Motivation
The other SDKs both use lower case for the platform. This is not a big deal but when it comes to metrics we will have 'Android' and 'android' showing up as different platforms.

Currently this is metrics when the cordova app and the ios showcase app bind to the same metrics server:

![screenshot 2018-05-31 10 24 08](https://user-images.githubusercontent.com/7307251/40776796-bfad6c96-64c3-11e8-97db-923d97d50147.png)

