### PR TITLE
Fix rooted check false positive

### DIFF
--- a/packages/security/src/deviceTrust/checks/NonRootedCheck.ts
+++ b/packages/security/src/deviceTrust/checks/NonRootedCheck.ts
@@ -1,6 +1,6 @@
+import { isCordovaAndroid } from "@aerogear/core";
 import { SecurityCheck } from "../SecurityCheck";
 import { SecurityCheckResult } from "../SecurityCheckResult";
-import { isCordovaAndroid } from "@aerogear/core";
 
 declare var IRoot: any;
 declare var document: any;

--- a/packages/security/src/deviceTrust/checks/NonRootedCheck.ts
+++ b/packages/security/src/deviceTrust/checks/NonRootedCheck.ts
@@ -3,6 +3,8 @@ import { SecurityCheckResult } from "../SecurityCheckResult";
 
 declare var IRoot: any;
 declare var document: any;
+declare var device: any;
+declare var platform: any;
 
 /**
  * Check to detect whether a device is rooted (Android) or jailbroken (iOS).
@@ -28,12 +30,12 @@ export class NonRootedCheck implements SecurityCheck {
       }
 
       document.addEventListener("deviceready", () => {
-        if (!IRoot) {
-          reject(new Error("Could not find plugin IRoot."));
+        if (!IRoot || !device) {
+          reject(new Error("Could not find plugin for Root Check"));
           return;
         }
-
-        IRoot.isRooted((rooted: number) => {
+        const isRootedCheck = device.platform === "Android" ? IRoot.isRootedRedBeer : IRoot.isRooted;
+        isRootedCheck((rooted: number) => {
           const result: SecurityCheckResult = { name: this.name, passed: !rooted };
           return resolve(result);
         }, (error: string) => reject(error));

--- a/packages/security/src/deviceTrust/checks/NonRootedCheck.ts
+++ b/packages/security/src/deviceTrust/checks/NonRootedCheck.ts
@@ -1,10 +1,9 @@
 import { SecurityCheck } from "../SecurityCheck";
 import { SecurityCheckResult } from "../SecurityCheckResult";
+import { isCordovaAndroid } from "@aerogear/core";
 
 declare var IRoot: any;
 declare var document: any;
-declare var device: any;
-declare var platform: any;
 
 /**
  * Check to detect whether a device is rooted (Android) or jailbroken (iOS).
@@ -30,11 +29,11 @@ export class NonRootedCheck implements SecurityCheck {
       }
 
       document.addEventListener("deviceready", () => {
-        if (!IRoot || !device) {
-          reject(new Error("Could not find plugin for Root Check"));
+        if (!IRoot) {
+          reject(new Error("Could not find plugin IRoot"));
           return;
         }
-        const isRootedCheck = device.platform === "Android" ? IRoot.isRootedRedBeer : IRoot.isRooted;
+        const isRootedCheck = isCordovaAndroid ? IRoot.isRootedRedBeer : IRoot.isRooted;
         isRootedCheck((rooted: number) => {
           const result: SecurityCheckResult = { name: this.name, passed: !rooted };
           return resolve(result);


### PR DESCRIPTION
## Motivation

Issue https://github.com/aerogear/aerogear-js-sdk/issues/105

Currently, RootBeer sometimes gives a false positive result to the check. This is often because the manufacturer of the device rom has left the busy box binary.

## Description
We have added a check to the Rootcheck to detect the device platform, as this is a specific problem for android. If the device is an android device we invoke the `isRootedRedBeer` function, this reduces the likely hood of a false positive result. If the device is not an android device we invoke the `isRooted` function.

## Additional Notes
**Important** I have verified this on an Android emulator only, this will need to be verified on an actual rooted device as well as ios to ensure it works.

## Verify
Navigate to the device trust page in the showcase app and observe the result, if the device is rooted the check should fail with the message 'device rooted detected' whereas if the device is not rooted the check should pass with the message 'device rooted not detected'
