### PR TITLE
Fix - auth constructor config

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -23,11 +23,11 @@ export class Auth {
       const serviceConfiguration: ServiceConfiguration = configuration[0];
       this.internalConfig = serviceConfiguration.config;
       // create a resource field containing the clientID. The keycloak JS adapter expects a clientId.
-      if (this.internalConfig.clientId === undefined){
+      if (!this.internalConfig.clientId) {
         this.internalConfig.clientId = this.internalConfig.resource;
       }
       // use the top level keycloak url in the mobile services json
-      this.internalConfig.url = serviceConfiguration.url
+      this.internalConfig.url = serviceConfiguration.url;
     }
     this.auth = Keycloak(this.internalConfig);
   }

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -20,12 +20,7 @@ export class Auth {
       console.warn("Keycloak configuration is missing. Authentication will not work properly.");
       this.internalConfig = {};
     } else {
-      const serviceConfiguration: ServiceConfiguration = configuration[0];
-      this.internalConfig = serviceConfiguration.config;
-      // create a resource field containing the clientID. The keycloak JS adapter expects a clientId.
-      this.internalConfig.clientId = this.internalConfig.resource;
-      // use the top level keycloak url in the mobile services json
-      this.internalConfig.url = serviceConfiguration.url;
+      this.internalConfig = configuration[0].config;
     }
     this.auth = Keycloak(this.internalConfig);
   }

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -20,7 +20,14 @@ export class Auth {
       console.warn("Keycloak configuration is missing. Authentication will not work properly.");
       this.internalConfig = {};
     } else {
-      this.internalConfig = configuration[0].config;
+      const serviceConfiguration: ServiceConfiguration = configuration[0];
+      this.internalConfig = serviceConfiguration.config;
+      // create a resource field containing the clientID. The keycloak JS adapter expects a clientId.
+      if (this.internalConfig.clientId === undefined){
+        this.internalConfig.clientId = this.internalConfig.resource;
+      }
+      // use the top level keycloak url in the mobile services json
+      this.internalConfig.url = serviceConfiguration.url
     }
     this.auth = Keycloak(this.internalConfig);
   }


### PR DESCRIPTION
## Motivation

Currently while running the showcase app keycloak fails to configure properly, this leaves any attempt to interact with keycloak as returning undefined.

This change just sets the internalConfig to the config file only, as clientId and the url is exposed through the config.

## Verify
To verify boot up the showcase template application and run through the authentication process, the access control, and the network tab.



