### PR TITLE
ci: allow any tag to kick off release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,6 @@ workflows:
             - build
           filters:
             tags:
-              only: /\d\.\d\.\d/
+              only: /.*/ # allow anything because tag syntax is validated as part of validate-release.sh
             branches:
               ignore: /.*/


### PR DESCRIPTION
CircleCI does a bad job of validating these tags. It is also redundant here because we do our own validation as part of the release. Much better for the release to kick off and fail over the release not ever kicking off because that would leave people very confused

