### PR TITLE
Fix is rooted check by invoking android check function

### DIFF
--- a/packages/security/src/deviceTrust/checks/NonRootedCheck.ts
+++ b/packages/security/src/deviceTrust/checks/NonRootedCheck.ts
@@ -33,7 +33,7 @@ export class NonRootedCheck implements SecurityCheck {
           reject(new Error("Could not find plugin IRoot"));
           return;
         }
-        const isRootedCheck = isCordovaAndroid ? IRoot.isRootedRedBeer : IRoot.isRooted;
+        const isRootedCheck = isCordovaAndroid() ? IRoot.isRootedRedBeer : IRoot.isRooted;
         isRootedCheck((rooted: number) => {
           const result: SecurityCheckResult = { name: this.name, passed: !rooted };
           return resolve(result);


### PR DESCRIPTION
## Motivation
Currently we are not invoking the Android check function in the
rooted check. The object we're checking will always evaluate to
true, meaning we're always trying to perform an Android-specific
check. Causing the check to crash on iOS.

## Description
This fixes the check by invoking the function.

## Progress
- [x] Invoke the Android check function


