### PR TITLE
Add check to getConfigByType function

### DIFF
--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -30,7 +30,12 @@ export class AgsCore {
    */
   public getConfigByType(type: string): ServiceConfiguration[] | undefined {
     if (this.configurations) {
-      return this.configurations.filter(service => service.type.toLowerCase() === type.toLowerCase());
+      return this.configurations.filter(service => {
+        if (!service.type) {
+          return false;
+        }
+        return service.type.toLowerCase() === type.toLowerCase()
+      });
     }
     console.error("Configuration not initialized.");
   }

--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -41,7 +41,7 @@ export class AgsCore {
    */
   public getConfigById(id: string): ServiceConfiguration | undefined {
     if (this.configurations) {
-      return find(this.configurations, service => !!service.type && service.id.toLowerCase() === id.toLowerCase());
+      return find(this.configurations, service => !!service.id && service.id.toLowerCase() === id.toLowerCase());
     }
     console.error("Configuration not initialized.");
   }

--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -30,12 +30,7 @@ export class AgsCore {
    */
   public getConfigByType(type: string): ServiceConfiguration[] | undefined {
     if (this.configurations) {
-      return this.configurations.filter(service => {
-        if (!service.type) {
-          return false;
-        }
-        return service.type.toLowerCase() === type.toLowerCase()
-      });
+      return this.configurations.filter(service => service.type && service.type.toLowerCase() === type.toLowerCase());
     }
     console.error("Configuration not initialized.");
   }

--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -41,7 +41,7 @@ export class AgsCore {
    */
   public getConfigById(id: string): ServiceConfiguration | undefined {
     if (this.configurations) {
-      return find(this.configurations, service => service.id.toLowerCase() === id.toLowerCase());
+      return find(this.configurations, service => !!service.type && service.id.toLowerCase() === id.toLowerCase());
     }
     console.error("Configuration not initialized.");
   }


### PR DESCRIPTION
## Motivation

Currently, if there is a blank service object in the `mobile-service.json` it causes the SDK to fall over,  by handling it and returning the object as false, the core remains stable and the missing config is picked up by our individual modules on init.

## Verify
- Remove one of the service objects and replace with a blank object in the example app
- Run the app, and it should crash on startup
- Symlink this PR changes to the example app.
- Rerun the app, it will not crash on startup


