### PR TITLE
Add a has/get config function to push and auth

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -110,4 +110,12 @@ export class Auth {
   public getConfig(): string[] {
     return this.internalConfig;
   }
+
+  /**
+   * Return true if config is present
+   */
+  public hasConfig(): any {
+    const configuration = INSTANCE.getConfigByType(Auth.TYPE);
+    return (!configuration || configuration.length === 0) ? false : true;
+  }
 }

--- a/packages/push/src/PushRegistration.ts
+++ b/packages/push/src/PushRegistration.ts
@@ -19,7 +19,7 @@ export class PushRegistration {
   public static readonly TYPE: string = "push";
   public static readonly API_PATH: string = "rest/registry/device";
 
-  public pushConfig: any;
+  private pushConfig: any;
 
   constructor() {
     const configuration = INSTANCE.getConfigByType(PushRegistration.TYPE);
@@ -80,5 +80,20 @@ export class PushRegistration {
     return new Promise((resolve, reject) => {
       return instance.post(PushRegistration.API_PATH, postData).then(() => resolve()).catch(reject);
     });
+  }
+
+  /**
+   * Return the config used for the push service
+   */
+  public getConfig(): any {
+    return this.pushConfig;
+  }
+
+  /**
+   * Return true if config is present
+   */
+  public hasConfig(): any {
+    const configuration = INSTANCE.getConfigByType(PushRegistration.TYPE);
+    return (!configuration || configuration.length === 0) ? false : true;
   }
 }


### PR DESCRIPTION
## Motivation

Currently, we offer a `getConfig` function in our auth module and we do not have a `getConfig` in our push module, but the config variable is public allowing a user to reference it directly.
We also don't have a function to allow a user to check if the service has a config object.

## Description

This change creates a `hasConfig()` file in both `auth` and `push` it also adds a `getConfig()` to push while making the config private. 

## Verify

- Checkout this PR the root directory run the following:
```
$ npm i
$ npm run bootstrap
$ npm run build
$ npm run link
```
- Navigate to your cordova showcase template and checkout https://github.com/aerogear/cordova-showcase-template/pull/82 
- From the root directory run the following:
```
npm i
npm run linkDev
```
Run the application, the app should run like normal, now remove push or auth and re-run the application and it should fail gracefully, a dialog box will be shown if you try to navigate to auth or push informing you of incorrect config.

