### PR TITLE
WIP: Aerogear 3296

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@aerogear/core": "1.0.0-alpha.1",
-    "keycloak-js": "4.0.0-beta.1",
+    "keycloak-js": "git://github.com/StephenCoady/keycloak-js-bower.git#master",
     "loglevel": "^1.6.1",
     "url": "^0.11.0"
   }


### PR DESCRIPTION
## Motivation

JIRA: https://issues.jboss.org/browse/AEROGEAR-3296

This PR fixes an issue where (in a development environment) it is currently not possible to login from a cordova app as the cordova adapter [here](https://github.com/keycloak/keycloak-js-bower/blob/master/dist/keycloak.js#L1289) always uses localhost.

**The Solution**
This PR, along with https://github.com/aerogear/cordova-showcase-template/pull/78 solves this problem by:

1. Forcing the keycloak js adapter to use the "default" adapter.
2. Makes some changes to keycloak by making a function used by init publicly available
3. Handling the flow of login/logout slightly differently (due to the fact we now lose some context upon switching between the browser and the app)

The major drawback of this solution is that it requires us to have our own fork of the Keycloak JS adapter. This is because since we are using it in a way they don't prescribe the chances of us getting any changes merged upstream are slim. 