### PR TITLE
Refactor docs script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ cordova-example
 
 docs/api/**
 
+docs.aerogear.org
+

--- a/.gitignore
+++ b/.gitignore
@@ -89,5 +89,5 @@ cordova-example
 
 docs/api/**
 
-docs.aerogear.org
+docs/docs.aerogear.org
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "clean:dependencies": "lerna clean --yes",
     "update:check": "lerna exec --concurrency 1 -- ncu",
     "update:run": "lerna exec -- ncu -a --removeRange -x 'fh-js-sdk'",
-    "depcheck": "lerna exec --parallel --stream -- depcheck --dev --specials='mocha,bin' --ignores='ts-node,@types/*' --ignore-dirs='example'"
+    "depcheck": "lerna exec --parallel --stream -- depcheck --dev --specials='mocha,bin' --ignores='ts-node,@types/*' --ignore-dirs='example'",
+    "generate:docs": "./scripts/docs.sh"
   },
   "devDependencies": {
     "del-cli": "1.1.0",

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -16,15 +16,8 @@ else
     rm -rf $DOCS_LOCATION
 fi
 
-echo "Piping Config to lerna.json"
-# Ensure the package names are correct
-echo "{\"lerna\": \"2.9.0\",\"packages\": [\"packages/app\",\"packages/auth\",\"packages/core\",\"packages/push\",\"packages/security\"],\"commands\": {\"publish\": {\"exact\": true}},\"version\": \"1.0.0-alpha.1\"}" > ${PWD}/lerna.json 
-
 echo "Generate documentation for packages"
-${PWD}/node_modules/.bin/lerna exec -- $TYPEDOC --mode file --out $DOCS_LOCATION/\${LERNA_PACKAGE_NAME:10} --excludePrivate --excludeExternals src/
-
-echo "Restoring lerna.json"
-echo "{\"lerna\": \"2.9.0\",\"packages\": [\"packages/*\"],\"commands\": {\"publish\": {\"exact\": true}},\"version\": \"1.0.0-alpha.1\"}" > ${PWD}/lerna.json
+${PWD}/node_modules/.bin/lerna exec --ignore "@aerogear/cordova-*" -- $TYPEDOC --mode file --out $DOCS_LOCATION/\${LERNA_PACKAGE_NAME:10} --excludePrivate --excludeExternals src/
 
 echo "Documentation was generated. Go to docs -> docs.aerogear.org to view new documentation"
 

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -2,13 +2,29 @@
 ## Script for generating core modules documentation
 
 VERSION=1.1.0
-DOC_FOLDER=docs
-DOCS_LOCATION=${PWD}/$DOC_FOLDER/api
+DOC_FOLDER=docs.aerogear.org
+DOCS_LOCATION=${PWD}/docs/$DOC_FOLDER/api/cordova/latest
 TYPEDOC=${PWD}/node_modules/.bin/typedoc # Need to use root typedoc to pick up typedoc plugin
 
-rm -rf $DOCS_LOCATION
+echo "Setting up Docs.Aerogear.org"
+if [ ! -d "$DOCS_LOCATION" ]; then
+    git clone git@github.com:aerogear/docs.aerogear.org.git
+    echo "Moving repo to docs folder"
+    mv ${PWD}/$DOC_FOLDER ${PWD}/docs/
+else 
+    echo "Removing existing documentation"
+    rm -rf $DOCS_LOCATION
+fi
+
+echo "Piping Config to lerna.json"
+# Ensure the package names are correct
+echo "{\"lerna\": \"2.9.0\",\"packages\": [\"packages/app\",\"packages/auth\",\"packages/core\",\"packages/push\",\"packages/security\"],\"commands\": {\"publish\": {\"exact\": true}},\"version\": \"1.0.0-alpha.1\"}" > ${PWD}/lerna.json 
 
 echo "Generate documentation for packages"
-${PWD}/node_modules/.bin/lerna exec -- $TYPEDOC --mode file --out $DOCS_LOCATION/\$LERNA_PACKAGE_NAME --excludePrivate --excludeExternals src/
+${PWD}/node_modules/.bin/lerna exec -- $TYPEDOC --mode file --out $DOCS_LOCATION/\${LERNA_PACKAGE_NAME:10} --excludePrivate --excludeExternals src/
 
-echo "Documentation was generated. Please continue website relase directly in documentation repository"
+echo "Restoring lerna.json"
+echo "{\"lerna\": \"2.9.0\",\"packages\": [\"packages/*\"],\"commands\": {\"publish\": {\"exact\": true}},\"version\": \"1.0.0-alpha.1\"}" > ${PWD}/lerna.json
+
+echo "Documentation was generated. Go to docs -> docs.aerogear.org to view new documentation"
+


### PR DESCRIPTION
## Motivation
Currently, the docs script falls over due to the Cordova plugins not containing an `src` directory. 
## Description
This change clones the docs.aerogear.org repo into the docs directory,  it pipes a different config to the `lerna.json`, this specifies the modules we want to generate documentation for. It runs the typedoc script and places the output in the appropriate location within the docs.aerogear.org repo. Before completing it pipes back in the old config to the `lerna.json` file
## Verify
- Checkout PR
- Run `npm run generate:docs`
- Navigate to docs -> docs,aerogear.org -> api -> cordova -> latest to view the new documentation
- Rerun `npm run generate:docs`
- The script should run with no issue.

