### PR TITLE
added base for conflict link

### DIFF
--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -38,9 +38,11 @@
     "apollo-cache-inmemory": "1.3.9",
     "apollo-cache-persist": "^0.1.1",
     "apollo-client": "2.4.5",
+    "apollo-link-error": "^1.1.1",
     "apollo-link-http": "^1.5.5",
     "apollo-link-ws": "^1.0.9",
     "graphql": "^14.0.2",
-    "subscriptions-transport-ws": "^0.9.15"
+    "subscriptions-transport-ws": "^0.9.15",
+    "deepmerge": "^2.2.1"
   }
 }

--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -1,13 +1,13 @@
+import { ConflictResolutionStrategy } from "../conflicts/strategies";
 import { LinkChainBuilder } from "../links/LinksBuilder";
 import { PersistedData, PersistentStore } from "../PersistentStore";
-import { IDataSyncConfig } from "./DataSyncClientConfig";
 
 /**
  * Contains all configuration options required to initialize SDK
  *
  * @see DefaultOptions for defaults
  */
-export interface IDataSyncConfig {
+export interface DataSyncConfig {
   /**
    * Http server url
    */
@@ -27,6 +27,11 @@ export interface IDataSyncConfig {
    * Storage solution
    */
   storage?: PersistentStore<PersistedData>;
+
+  /**
+   * Conflict resolution strategy
+   */
+  conflictStrategy?: ConflictResolutionStrategy;
 
   /**
    * Enables providing custom Apollo Link for processing requests

--- a/packages/sync/src/config/DefaultConfig.ts
+++ b/packages/sync/src/config/DefaultConfig.ts
@@ -1,6 +1,6 @@
 import { INSTANCE, ServiceConfiguration } from "@aerogear/core";
 import { ConfigError } from "./ConfigError";
-import { IDataSyncConfig } from "./DataSyncClientConfig";
+import { DataSyncConfig } from "./DataSyncConfig";
 
 declare var window: any;
 
@@ -11,7 +11,7 @@ const TYPE: string = "sync";
  * Class for managing user and default configuration.
  * Default config is applied on top of user provided configuration
  */
-export class SyncConfig implements IDataSyncConfig {
+export class SyncConfig implements DataSyncConfig {
   // Explicitly use id as id field
   public dataIdFromObject = "id";
   // Use browser storage by default
@@ -24,7 +24,7 @@ export class SyncConfig implements IDataSyncConfig {
   /**
    * Method used to join user configuration with defaults
    */
-  public merge(clientOptions?: IDataSyncConfig): IDataSyncConfig {
+  public merge(clientOptions?: DataSyncConfig): DataSyncConfig {
     return Object.assign(this, clientOptions);
   }
 
@@ -33,7 +33,7 @@ export class SyncConfig implements IDataSyncConfig {
    *
    * @param config user supplied configuration
    */
-  public applyPlatformConfig(config: IDataSyncConfig) {
+  public applyPlatformConfig(config: DataSyncConfig) {
     const configuration = INSTANCE.getConfigByType(TYPE);
     if (configuration && configuration.length > 0) {
       const serviceConfiguration: ServiceConfiguration = configuration[0];
@@ -41,7 +41,7 @@ export class SyncConfig implements IDataSyncConfig {
     }
   }
 
-  public validate(userConfig: IDataSyncConfig) {
+  public validate(userConfig: DataSyncConfig) {
     if (!userConfig.httpUrl) {
       throw new ConfigError("Missing server URL", "httpUrl");
     }

--- a/packages/sync/src/conflicts/conflictLink.ts
+++ b/packages/sync/src/conflicts/conflictLink.ts
@@ -20,7 +20,7 @@ export const conflictLink = (config: DataSyncConfig) => {
                 }
             }
         }
-    }
+    };
     /**
      * Fetch the conflict strategy if one is provided, if not return client wins.
      */
@@ -30,7 +30,7 @@ export const conflictLink = (config: DataSyncConfig) => {
         } else {
             return strategies.diffMergeClientWins;
         }
-    }
+    };
 
     return onError(({ operation, forward, graphQLErrors }) => {
         const data = getConflictData(graphQLErrors);

--- a/packages/sync/src/conflicts/conflictLink.ts
+++ b/packages/sync/src/conflicts/conflictLink.ts
@@ -1,3 +1,4 @@
+import { ApolloLink, FetchResult, NextLink, Observable, Operation } from "apollo-link";
 import { onError } from "apollo-link-error";
 import { GraphQLError } from "graphql";
 import { DataSyncConfig } from "../config/DataSyncConfig";
@@ -19,8 +20,7 @@ export const conflictLink = (config: DataSyncConfig) => {
                 }
             }
         }
-    };
-
+    }
     /**
      * Fetch the conflict strategy if one is provided, if not return client wins.
      */
@@ -30,9 +30,9 @@ export const conflictLink = (config: DataSyncConfig) => {
         } else {
             return strategies.diffMergeClientWins;
         }
-    };
+    }
 
-    return onError(({ graphQLErrors, operation, forward }) => {
+    return onError(({ operation, forward, graphQLErrors }) => {
         const data = getConflictData(graphQLErrors);
         const resolvedConflict = getConflictStrategy()(data, operation.variables);
         // TODO Notify
@@ -40,5 +40,4 @@ export const conflictLink = (config: DataSyncConfig) => {
         operation.variables = resolvedConflict;
         return forward(operation);
     });
-
 };

--- a/packages/sync/src/conflicts/conflictLink.ts
+++ b/packages/sync/src/conflicts/conflictLink.ts
@@ -1,0 +1,51 @@
+import { ApolloLink } from "apollo-link";
+import { onError } from "apollo-link-error";
+import { GraphQLError } from "graphql";
+import { DataSyncConfig } from "../config/DataSyncConfig";
+import { ConflictResolutionData, strategies } from "./strategies";
+
+export class ConflictLink {
+    private config: DataSyncConfig;
+
+    constructor(config: DataSyncConfig) {
+        this.config = config;
+    }
+
+    /**
+     * Initialise the conflict link
+     * @returns An apollo link capable of detecting errors
+     */
+    public init(): ApolloLink {
+        const link = onError(({ graphQLErrors, operation, forward }) => {
+            const data = this.getConflictData(graphQLErrors);
+            if (!this.config.conflictStrategy) {
+                this.config.conflictStrategy = strategies.diffMergeClientWins;
+            }
+            const resolvedConflict = this.config.conflictStrategy(data, operation.variables);
+            // TODO Notify
+            resolvedConflict.version = data.version;
+            operation.variables = resolvedConflict;
+            return forward(operation);
+        });
+
+        return link;
+    }
+
+    /**
+    * Fetch conflict data from the errors returned from the server
+    * @param graphQLErrors array of errors to retrieve conflicted data from
+    */
+    private getConflictData = (graphQLErrors?: ReadonlyArray<GraphQLError>): ConflictResolutionData => {
+        if (graphQLErrors) {
+            for (const err of graphQLErrors) {
+                if (err.extensions) {
+                    // TODO need to add flag to check if conflict was resolved on the server
+                    if (err.extensions.exception.type === "AgSync:DataConflict") {
+                        return err.extensions.exception.data;
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/packages/sync/src/conflicts/strategies.ts
+++ b/packages/sync/src/conflicts/strategies.ts
@@ -1,0 +1,19 @@
+import deepmerge from "deepmerge";
+
+const diffMergeClientWins = (server: ConflictResolutionData, client: ConflictResolutionData) => {
+    return deepmerge(server, client);
+};
+const diffMergeServerWins = (server: ConflictResolutionData, client: ConflictResolutionData) => {
+    return deepmerge(client, server);
+};
+
+export const strategies = {
+    diffMergeClientWins,
+    diffMergeServerWins
+};
+
+// Separate file
+export type ConflictResolutionData = any;
+
+export type ConflictResolutionStrategy =
+    (server: ConflictResolutionData, client: ConflictResolutionData) => ConflictResolutionData;

--- a/packages/sync/src/createClient.ts
+++ b/packages/sync/src/createClient.ts
@@ -1,7 +1,7 @@
 import { InMemoryCache } from "apollo-cache-inmemory";
 import { persistCache } from "apollo-cache-persist";
 import { ApolloClient } from "apollo-client";
-import { IDataSyncConfig } from "./config/DataSyncConfig";
+import { DataSyncConfig } from "./config/DataSyncConfig";
 import { SyncConfig } from "./config/DefaultConfig";
 import { defaultLinkBuilder as buildLink} from "./links/LinksBuilder";
 import { PersistedData, PersistentStore } from "./PersistentStore";
@@ -11,7 +11,7 @@ import { PersistedData, PersistentStore } from "./PersistentStore";
  *
  * @param options options object used to build client
  */
-export const createClient = async (userConfig?: IDataSyncConfig) => {
+export const createClient = async (userConfig?: DataSyncConfig) => {
 
   const clientConfig = extractConfig(userConfig);
   const cache = await buildStorage(clientConfig);
@@ -23,7 +23,7 @@ export const createClient = async (userConfig?: IDataSyncConfig) => {
 /**
  * Extract configuration from user and external sources
  */
-function extractConfig(userConfig: IDataSyncConfig | undefined) {
+function extractConfig(userConfig: DataSyncConfig | undefined) {
   const config = new SyncConfig();
   const clientConfig = config.merge(userConfig);
   config.applyPlatformConfig(clientConfig);
@@ -36,7 +36,7 @@ function extractConfig(userConfig: IDataSyncConfig | undefined) {
  *
  * @param clientConfig
  */
-async function buildStorage(clientConfig: IDataSyncConfig) {
+async function buildStorage(clientConfig: DataSyncConfig) {
   const cache = new InMemoryCache({
     dataIdFromObject: () =>  clientConfig.dataIdFromObject
   });

--- a/packages/sync/src/createClient.ts
+++ b/packages/sync/src/createClient.ts
@@ -1,7 +1,7 @@
 import { InMemoryCache } from "apollo-cache-inmemory";
 import { persistCache } from "apollo-cache-persist";
 import { ApolloClient } from "apollo-client";
-import { IDataSyncConfig } from "./config/DataSyncClientConfig";
+import { IDataSyncConfig } from "./config/DataSyncConfig";
 import { SyncConfig } from "./config/DefaultConfig";
 import { defaultLinkBuilder as buildLink} from "./links/LinksBuilder";
 import { PersistedData, PersistentStore } from "./PersistentStore";

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./createClient";
-export * from "./config/DataSyncClientConfig";
+export * from "./config/DataSyncConfig";
 export * from "./links/LinksBuilder";
+export * from "./conflicts/strategies";

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -1,20 +1,20 @@
 import { ApolloLink, split } from "apollo-link";
 import { HttpLink } from "apollo-link-http";
 import { getMainDefinition } from "apollo-utilities";
-import { IDataSyncConfig } from "../config/DataSyncConfig";
+import { DataSyncConfig } from "../config/DataSyncConfig";
 import { defaultWebSocketLink } from "./WebsocketLink";
 
 /**
  * Function used to build apollo link
  */
-export type LinkChainBuilder = (config: IDataSyncConfig) => ApolloLink;
+export type LinkChainBuilder = (config: DataSyncConfig) => ApolloLink;
 
 /**
  * Default Apollo Link builder
  * Provides out of the box functionality for the users
  */
 export const defaultLinkBuilder: LinkChainBuilder =
-  (config: IDataSyncConfig): ApolloLink => {
+  (config: DataSyncConfig): ApolloLink => {
     if (config.customLinkBuilder) {
       return config.customLinkBuilder(config);
     }

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -1,7 +1,7 @@
 import { ApolloLink, split } from "apollo-link";
 import { HttpLink } from "apollo-link-http";
 import { getMainDefinition } from "apollo-utilities";
-import { IDataSyncConfig } from "../config/DataSyncClientConfig";
+import { IDataSyncConfig } from "../config/DataSyncConfig";
 import { defaultWebSocketLink } from "./WebsocketLink";
 
 /**


### PR DESCRIPTION
NOTE: Stalling work on this PR to focus on tickets being brought into the spring.

## Motivation
https://issues.jboss.org/browse/AEROGEAR-8091

## What
Added a base for conflict detection. Also exports two basic strategies for use by the client.

## Verification

First clone this branch and from within `packages/sync` run `npm link .`

Then from within the offline strategies repo, on this branch: https://github.com/aerogear/offline-conflict-strategies/pull/34

1. Run the server:
```
cd server
docker-compose up -d
npm i
npm run start
```

2. Run the app:
```
cd web
npm i
npm link @aerogear/datasync-js
npm run start 
```

3. Trigger the conflict:
When the app is running open two separate browser windows (must not both be the same browser - or one should be incognito).
Create a user and have it displayed on both windows.
Edit the user on one window.
Try to edit the user on the second window. The second window should win and the conflict should be displayed in the consoles.

## Progress

- [x] Add basic conflict detection using Apollo link error
- [x] Add two basic strategies
- [ ] Add flag to check if the server has resolved the conflict before it returns to the client
- [ ] Add a notification handler to always return information about the conflict to the client, possibly through some hook to the client
- [ ] Implement the conflict link in the createClient file so that it can be used/tested with a client

