### PR TITLE
Wrapper for Cordova Plugins used for Sync

### DIFF
--- a/packages/sync-cordova/README.md
+++ b/packages/sync-cordova/README.md
@@ -1,0 +1,18 @@
+## AeroGear Sync Cordova plugin
+
+Wrapper for Cordova plugins used in DataSync SDK
+
+Includes following plugins:
+- [Network Information](https://github.com/apache/cordova-plugin-network-information/)
+
+## Installation
+
+```
+cordova plugin add @aerogear/cordova-plugin-aerogear-sync
+```
+
+## Using development version of plugin
+
+```
+cordova plugin add ./sync-cordova --link
+```

--- a/packages/sync-cordova/package.json
+++ b/packages/sync-cordova/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "bugs": {
-    "url": "https://issues.jboss.org/projects/AGCORDOVA/issues"
+    "url": "https://issues.jboss.org/browse/AEROGEAR"
   },
   "homepage": "https://github.com/aerogear/aerogear-js-sdk#readme"
 }

--- a/packages/sync-cordova/package.json
+++ b/packages/sync-cordova/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@aerogear/cordova-plugin-aerogear-sync",
+  "version": "2.0.0",
+  "description": "Cordova plugin for AeroGear Sync",
+  "cordova": {
+    "id": "cordova-plugin-aerogear-sync",
+    "platforms": []
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aerogear/aerogear-js-sdk.git"
+  },
+  "keywords": [
+    "ecosystem:cordova"
+  ],
+  "author": "Aerogear <aerogear@googlegroups.com>",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://issues.jboss.org/projects/AGCORDOVA/issues"
+  },
+  "homepage": "https://github.com/aerogear/aerogear-js-sdk#readme"
+}

--- a/packages/sync-cordova/plugin.xml
+++ b/packages/sync-cordova/plugin.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<plugin
+    id="cordova-plugin-aerogear-sync"
+    version="2.0.0"
+    xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <name>cordova-plugin-aerogear-sync</name>
+
+    <dependency id="cordova-plugin-network-information" version="^2.0.1"/>
+
+
+</plugin>


### PR DESCRIPTION
## Motivation

I have created wrapper to follow patterns used in other SDK's (and documentation patterns). 
Before release we can verify if we use more than one plugin and validate if wrapper is still needed.
Using latest release