### PR TITLE
moved the sync after restart to be part of queue

### DIFF
--- a/packages/sync/src/createClient.ts
+++ b/packages/sync/src/createClient.ts
@@ -5,17 +5,16 @@ import { DataSyncConfig } from "./config/DataSyncConfig";
 import { SyncConfig } from "./config/SyncConfig";
 import { defaultLinkBuilder as buildLink } from "./links/LinksBuilder";
 import { PersistedData, PersistentStore } from "./PersistentStore";
-import { SyncOfflineMutation } from "./offline/SyncOfflineMutation";
 
 /**
  * Factory for creating Apollo Client
  *
  * @param userConfig options object used to build client
  */
-export const createClient = async (userConfig?: DataSyncConfig) => {
+export const createClient = async (userConfig?: DataSyncConfig, oldClient?: ApolloClient<NormalizedCacheObject>) => {
   const clientConfig = extractConfig(userConfig);
   const { cache } = await buildCachePersistence(clientConfig);
-  const link = buildLink(clientConfig);
+  const link = buildLink(clientConfig, oldClient);
   const apolloClient = new ApolloClient<NormalizedCacheObject>({
     link,
     cache

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -14,6 +14,7 @@ export type LinkChainBuilder = (config: DataSyncConfig) => ApolloLink;
 /**
  * Default Apollo Link builder
  * Provides out of the box functionality for:
+ *
  * - Subscription handling
  * - Offline/Online queue
  * - Conflict resolution
@@ -25,7 +26,6 @@ export const defaultLinkBuilder: LinkChainBuilder =
       return config.customLinkBuilder(config);
     }
     const httpLink = new HttpLink({ uri: config.httpUrl });
-
     const queueMutationsLink = new QueueLink(config);
     let links: ApolloLink[] = [queueMutationsLink, conflictLink(config), httpLink];
 

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -13,7 +13,11 @@ export type LinkChainBuilder = (config: DataSyncConfig) => ApolloLink;
 
 /**
  * Default Apollo Link builder
- * Provides out of the box functionality for the users
+ * Provides out of the box functionality for:
+ * - Subscription handling
+ * - Offline/Online queue
+ * - Conflict resolution
+ * - Error handling
  */
 export const defaultLinkBuilder: LinkChainBuilder =
   (config: DataSyncConfig): ApolloLink => {

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -5,11 +5,13 @@ import { DataSyncConfig } from "../config/DataSyncConfig";
 import { defaultWebSocketLink } from "./WebsocketLink";
 import QueueLink from "./QueueLink";
 import { isSubscription } from "../utils/helpers";
+import ApolloClient from "apollo-client";
+import { NormalizedCacheObject } from "apollo-cache-inmemory";
 
 /**
  * Function used to build Apollo link
  */
-export type LinkChainBuilder = (config: DataSyncConfig) => ApolloLink;
+export type LinkChainBuilder = (config: DataSyncConfig, oldClient?: ApolloClient<NormalizedCacheObject>) => ApolloLink;
 
 /**
  * Default Apollo Link builder
@@ -21,12 +23,12 @@ export type LinkChainBuilder = (config: DataSyncConfig) => ApolloLink;
  * - Error handling
  */
 export const defaultLinkBuilder: LinkChainBuilder =
-  (config: DataSyncConfig): ApolloLink => {
+  (config: DataSyncConfig, oldClient?: ApolloClient<NormalizedCacheObject>): ApolloLink => {
     if (config.customLinkBuilder) {
-      return config.customLinkBuilder(config);
+      return config.customLinkBuilder(config, oldClient);
     }
     const httpLink = new HttpLink({ uri: config.httpUrl });
-    const queueMutationsLink = new QueueLink(config);
+    const queueMutationsLink = new QueueLink(config, oldClient);
     let links: ApolloLink[] = [queueMutationsLink, conflictLink(config), httpLink];
 
     if (!config.conflictStrategy) {

--- a/packages/sync/src/utils/helpers.ts
+++ b/packages/sync/src/utils/helpers.ts
@@ -1,0 +1,8 @@
+import { getMainDefinition } from "apollo-utilities";
+import { Operation } from "apollo-link";
+
+export const isSubscription = (op: Operation) => {
+  const query = op.query;
+  const { kind, operation } = getMainDefinition(op.query) as any;
+  return kind === "OperationDefinition" && operation === "subscription";
+};

--- a/packages/sync/src/utils/helpers.ts
+++ b/packages/sync/src/utils/helpers.ts
@@ -2,7 +2,6 @@ import { getMainDefinition } from "apollo-utilities";
 import { Operation } from "apollo-link";
 
 export const isSubscription = (op: Operation) => {
-  const query = op.query;
   const { kind, operation } = getMainDefinition(op.query) as any;
   return kind === "OperationDefinition" && operation === "subscription";
 };

--- a/packages/sync/test/QueueLink.test.ts
+++ b/packages/sync/test/QueueLink.test.ts
@@ -43,7 +43,7 @@ describe("OnOffLink", () => {
 
   beforeEach(() => {
     testLink = new TestLink();
-    onOffLink = new QueueLink(localStorage, "test");
+    onOffLink = new QueueLink({ mutationsQueueName: "test", storage: localStorage });
     link = ApolloLink.from([onOffLink, testLink]);
   });
 


### PR DESCRIPTION
ping @wtrocki this was what I was thinking originally. let me know what you think.

not sure what the client bootstrapping itself from its own state looks like, so this might not be a runner.