### PR TITLE
Aerogear 8146

### DIFF
--- a/packages/sync/src/conflicts/conflictLink.ts
+++ b/packages/sync/src/conflicts/conflictLink.ts
@@ -1,4 +1,3 @@
-import { ApolloLink, FetchResult, NextLink, Observable, Operation } from "apollo-link";
 import { onError } from "apollo-link-error";
 import { GraphQLError } from "graphql";
 import { DataSyncConfig } from "../config/DataSyncConfig";

--- a/packages/sync/src/conflicts/conflictLink.ts
+++ b/packages/sync/src/conflicts/conflictLink.ts
@@ -3,8 +3,9 @@ import { GraphQLError } from "graphql";
 import { DataSyncConfig } from "../config/DataSyncConfig";
 import { CONFLICT_ERROR } from "../config/Constants";
 import { ConflictResolutionData, ConflictResolutionStrategy, strategies } from "./strategies";
+import { ApolloLink } from "apollo-link";
 
-export const conflictLink = (config: DataSyncConfig) => {
+export const conflictLink = (config: DataSyncConfig): ApolloLink => {
   /**
   * Fetch conflict data from the errors returned from the server
   * @param graphQLErrors array of errors to retrieve conflicted data from

--- a/packages/sync/src/conflicts/index.ts
+++ b/packages/sync/src/conflicts/index.ts
@@ -1,1 +1,2 @@
 export * from "./strategies";
+export * from "./conflictLink";

--- a/packages/sync/src/createClient.ts
+++ b/packages/sync/src/createClient.ts
@@ -1,6 +1,6 @@
 import { InMemoryCache, NormalizedCacheObject } from "apollo-cache-inmemory";
 import { persistCache } from "apollo-cache-persist";
-import { ApolloClient, ApolloClientOptions } from "apollo-client";
+import { ApolloClient } from "apollo-client";
 import { DataSyncConfig } from "./config/DataSyncConfig";
 import { SyncConfig } from "./config/SyncConfig";
 import { defaultLinkBuilder as buildLink } from "./links/LinksBuilder";

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -1,6 +1,6 @@
 import { ApolloLink, split } from "apollo-link";
 import { HttpLink } from "apollo-link-http";
-import { conflictLink } from "../conflicts/conflictLink";
+import { conflictLink } from "../conflicts";
 import { DataSyncConfig } from "../config/DataSyncConfig";
 import { defaultWebSocketLink } from "./WebsocketLink";
 import { OfflineQueueLink } from "./OfflineQueueLink";

--- a/packages/sync/src/links/OfflineQueueLink.ts
+++ b/packages/sync/src/links/OfflineQueueLink.ts
@@ -93,7 +93,11 @@ export class OfflineQueueLink extends ApolloLink {
   }
 
   private enqueue(entry: OperationQueueEntry) {
-    this.opQueue = squashOperations(entry, this.opQueue);
+    if (hasDirectives([Directives.NO_SQUASH], entry.operation.query)) {
+      this.opQueue.push(entry);
+    } else {
+      this.opQueue = squashOperations(entry, this.opQueue);
+    }
     this.storage.setItem(this.key, JSON.stringify(this.opQueue));
   }
 

--- a/packages/sync/src/links/OfflineQueueLink.ts
+++ b/packages/sync/src/links/OfflineQueueLink.ts
@@ -93,11 +93,7 @@ export class OfflineQueueLink extends ApolloLink {
   }
 
   private enqueue(entry: OperationQueueEntry) {
-    if (hasDirectives([Directives.NO_SQUASH], entry.operation.query)) {
-      this.opQueue.push(entry);
-    } else {
-      this.opQueue = squashOperations(entry, this.opQueue);
-    }
+    this.opQueue = squashOperations(entry, this.opQueue);
     this.storage.setItem(this.key, JSON.stringify(this.opQueue));
   }
 

--- a/packages/sync/src/offline/squashOperations.ts
+++ b/packages/sync/src/offline/squashOperations.ts
@@ -1,11 +1,16 @@
 import { OperationDefinitionNode, NameNode } from "graphql";
-
+import { hasDirectives } from "apollo-utilities";
+import { Directives } from "../config/Constants";
 import { OperationQueueEntry } from "../links/OfflineQueueLink";
 /**
  * Merge offline operations that are made on the same object.
  * Equality of operation is done by checking operationName and object id.
  */
 export function squashOperations(entry: OperationQueueEntry, opQueue: OperationQueueEntry[]): OperationQueueEntry[] {
+  if (hasDirectives([Directives.NO_SQUASH], entry.operation.query)) {
+    opQueue.push(entry);
+    return opQueue;
+  }
   const { query, variables } = entry.operation;
   let operationName: NameNode;
 

--- a/packages/sync/test/OfflineQueueLink.test.ts
+++ b/packages/sync/test/OfflineQueueLink.test.ts
@@ -1,7 +1,7 @@
 // tslint:disable-next-line:ordered-imports
 /// <reference types="@types/mocha" />
 import {
-  ApolloLink, execute, GraphQLRequest
+  ApolloLink, execute, GraphQLRequest, Operation, NextLink
 } from "apollo-link";
 import gql from "graphql-tag";
 import { OfflineQueueLink as QueueLink } from "../src/links/OfflineQueueLink";
@@ -40,6 +40,49 @@ describe("OnOffLink", () => {
     context: {
       testResponse
     }
+  };
+
+  const opDirective: Operation = {
+    variables: {
+      name: "User 1",
+      dateOfBirth: "Fri Nov 30 2018 09:43:22 GMT+0000",
+      id: "1",
+      version: 3
+    },
+    operationName: "updateUser",
+    query: {
+      kind: "Document",
+      definitions: [{
+        kind: "OperationDefinition",
+        operation: "mutation",
+        name: {
+          kind: "Name",
+          value: "updateUser"
+        },
+        selectionSet: {
+          kind: "SelectionSet",
+          selections: [{
+            kind: "Field",
+            name: {
+              kind: "Name",
+              value: "updateUser"
+            },
+            directives: [{
+              kind: "Directive",
+              name: {
+                kind: "Name",
+                value: "noSquash"
+              },
+              arguments: []
+            }]
+          }]
+        }
+      }]
+    },
+    extensions: {} as any,
+    setContext: {} as any,
+    getContext: {} as any,
+    toKey: {} as any
   };
   const config = { mutationsQueueName: "test", storage: localStorage };
   beforeEach(() => {
@@ -120,6 +163,7 @@ describe("OnOffLink", () => {
     onOffLinkFilter.open();
     expect(testLink.operations.length).equal(1);
   });
+
   it("store test promises", () => {
     let operations: any[] = [];
     const storageEngine = {
@@ -142,5 +186,27 @@ describe("OnOffLink", () => {
     });
     onOffLinkFilter.open();
     expect(testLink.operations.length).equal(1);
+  });
+
+  it("noSquash Directive test", () => {
+    let operations: any[] = [];
+    const storageEngine = {
+      getItem() {
+        return operations;
+      },
+      removeItem() {
+        operations = [];
+      },
+      setItem(key: string, content: any) {
+        console.info(content);
+        operations = JSON.parse(content);
+      }
+    };
+    const localConfig = { mutationsQueueName: "test", storage: storageEngine };
+    const queueLink = new QueueLink(localConfig);
+    queueLink.close();
+    queueLink.request(opDirective, {} as NextLink).subscribe({});
+    queueLink.request(opDirective, {} as NextLink).subscribe({});
+    expect(localConfig.storage.getItem().length).eqls(2);
   });
 });

--- a/packages/sync/test/OfflineQueueLink.test.ts
+++ b/packages/sync/test/OfflineQueueLink.test.ts
@@ -1,7 +1,7 @@
 // tslint:disable-next-line:ordered-imports
 /// <reference types="@types/mocha" />
 import {
-  ApolloLink, execute, GraphQLRequest, Operation, NextLink
+  ApolloLink, execute, GraphQLRequest
 } from "apollo-link";
 import gql from "graphql-tag";
 import { OfflineQueueLink as QueueLink } from "../src/links/OfflineQueueLink";
@@ -42,48 +42,6 @@ describe("OnOffLink", () => {
     }
   };
 
-  const opDirective: Operation = {
-    variables: {
-      name: "User 1",
-      dateOfBirth: "Fri Nov 30 2018 09:43:22 GMT+0000",
-      id: "1",
-      version: 3
-    },
-    operationName: "updateUser",
-    query: {
-      kind: "Document",
-      definitions: [{
-        kind: "OperationDefinition",
-        operation: "mutation",
-        name: {
-          kind: "Name",
-          value: "updateUser"
-        },
-        selectionSet: {
-          kind: "SelectionSet",
-          selections: [{
-            kind: "Field",
-            name: {
-              kind: "Name",
-              value: "updateUser"
-            },
-            directives: [{
-              kind: "Directive",
-              name: {
-                kind: "Name",
-                value: "noSquash"
-              },
-              arguments: []
-            }]
-          }]
-        }
-      }]
-    },
-    extensions: {} as any,
-    setContext: {} as any,
-    getContext: {} as any,
-    toKey: {} as any
-  };
   const config = { mutationsQueueName: "test", storage: localStorage };
   beforeEach(() => {
     testLink = new TestLink();
@@ -188,25 +146,4 @@ describe("OnOffLink", () => {
     expect(testLink.operations.length).equal(1);
   });
 
-  it("noSquash Directive test", () => {
-    let operations: any[] = [];
-    const storageEngine = {
-      getItem() {
-        return operations;
-      },
-      removeItem() {
-        operations = [];
-      },
-      setItem(key: string, content: any) {
-        console.info(content);
-        operations = JSON.parse(content);
-      }
-    };
-    const localConfig = { mutationsQueueName: "test", storage: storageEngine };
-    const queueLink = new QueueLink(localConfig);
-    queueLink.close();
-    queueLink.request(opDirective, {} as NextLink).subscribe({});
-    queueLink.request(opDirective, {} as NextLink).subscribe({});
-    expect(localConfig.storage.getItem().length).eqls(2);
-  });
 });

--- a/packages/sync/test/SquashOperation.test.ts
+++ b/packages/sync/test/SquashOperation.test.ts
@@ -1,6 +1,3 @@
-import {
-  Operation, NextLink, execute
-} from "apollo-link";
 import { squashOperations } from "../src/offline/squashOperations";
 import { OfflineQueueLink as QueueLink, OperationQueueEntry } from "../src/links/OfflineQueueLink";
 import { expect } from "chai";

--- a/packages/sync/test/operations.ts
+++ b/packages/sync/test/operations.ts
@@ -1,0 +1,100 @@
+import { Operation } from "apollo-link";
+
+const op: Operation = {
+  variables: {
+    name: "User 1",
+    id: 5,
+    dateOfBirth: "1/1/18",
+    address: "GraphQL Lane",
+    version: 1
+  },
+  operationName: "updateUser",
+  query: {
+    kind: "Document",
+    definitions: [{
+      kind: "OperationDefinition",
+      selectionSet: {} as any,
+      operation: "mutation",
+      name: {
+        kind: "Name",
+        value: "updateUser"
+      }
+    }]
+  },
+  extensions: {} as any,
+  setContext: {} as any,
+  getContext: {} as any,
+  toKey: {} as any
+};
+
+const opWithDirective: Operation = {
+  variables: {
+    name: "User 1",
+    dateOfBirth: "Fri Nov 30 2018 09:43:22 GMT+0000",
+    id: "1",
+    version: 3
+  },
+  operationName: "updateUser",
+  query: {
+    kind: "Document",
+    definitions: [{
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: {
+        kind: "Name",
+        value: "updateUser"
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [{
+          kind: "Field",
+          name: {
+            kind: "Name",
+            value: "updateUser"
+          },
+          directives: [{
+            kind: "Directive",
+            name: {
+              kind: "Name",
+              value: "noSquash"
+            },
+            arguments: []
+          }]
+        }]
+      }
+    }]
+  },
+  extensions: {} as any,
+  setContext: {} as any,
+  getContext: {} as any,
+  toKey: {} as any
+};
+
+const opWithDifferentQuery: Operation = {
+  variables: {
+    name: "User 1",
+    id: 5,
+    dateOfBirth: "1/1/18",
+    address: "GraphQL Lane",
+    version: 1
+  },
+  operationName: "createUser",
+  query: {
+    kind: "Document",
+    definitions: [{
+      kind: "OperationDefinition",
+      selectionSet: {} as any,
+      operation: "mutation",
+      name: {
+        kind: "Name",
+        value: "createUser"
+      }
+    }]
+  },
+  extensions: {} as any,
+  setContext: {} as any,
+  getContext: {} as any,
+  toKey: {} as any
+};
+
+export { op, opWithDifferentQuery, opWithDirective };


### PR DESCRIPTION
Adding noSquash feature as per: https://issues.jboss.org/browse/AEROGEAR-8146

NOTE: The ticket specifies an isSquashable directive as opposed to noSquash which is what I have implemented. I feel this makes more sense as the majority of mutations will be squashable so it is opt out of squashing as opposed to opt in.

To try this out add @noSquash to your query and ensure `directive @noSquash on FIELD` is present in your typeDefs.

If you want, those changes are already on the branch [here](https://github.com/aerogear/offline-conflict-strategies/tree/directives-test)