### PR TITLE
Remove option to customize id

### DIFF
--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -141,3 +141,8 @@ exampleMutation(...) @noSquash {
   ...
 }
 ```
+
+## Designing your types
+
+When designing your GraphQL schema types `id` field is always required.
+Library will perform business logic assumming that `id` field will be supplied and returned from server. Without this field some offline functionalities will not work properly.

--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -20,11 +20,6 @@ export interface DataSyncConfig {
   wsUrl?: string;
 
   /**
-   * Describes name of the field used as ID
-   */
-  dataIdFromObject?: string | any;
-
-  /**
    * Storage solution
    */
   storage?: PersistentStore<PersistedData>;

--- a/packages/sync/src/config/SyncConfig.ts
+++ b/packages/sync/src/config/SyncConfig.ts
@@ -17,7 +17,6 @@ const TYPE: string = "sync";
  */
 export class SyncConfig implements DataSyncConfig {
   // Explicitly use id as id field
-  public dataIdFromObject = "id";
   public storage?: PersistentStore<PersistedData>;
   public mutationsQueueName = "offline-mutation-store";
   public squashing = true;


### PR DESCRIPTION
## Motivation

Remove option to customize id as we no longer use any id related stuff. 
This means that we can settle with default _id/id. If users will want to change that we could expose it again, but it's best to stick with default