### PR TITLE
Add offline queue listener

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 
 ## Default owners (going to be removed at later stage)
-@wtrocki
+@wtrocki @StephenCoady

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -5,19 +5,6 @@ Package maintained as part of AeroGear Services SDK.
 See: https://github.com/aerogear/aerogear-js-sdk for documentation
 
 
-# Contribution guide
-
-## Logging debug messages
-
-Sync package is using debug package to print out debug messages
-
-To enable debug please execute in console
-`localStorage.debug = 'AeroGearSync:*'`
-
-Some certain features can be enabled separately
-
-`localStorage.debug = 'AeroGearSync:OfflineMutations*'`
-
 # Importing the package
 ```javascript
 import {
@@ -140,3 +127,16 @@ exampleMutation(...) @noSquash {
 
 When designing your GraphQL schema types `id` field is always required.
 Library will perform business logic assuming that `id` field will be supplied and returned from server. Without this field some offline functionalities will not work properly.
+
+# Contribution guide
+
+## Logging debug messages
+
+Sync package is using debug package to print out debug messages
+
+To enable debug please execute in console
+`localStorage.debug = 'AeroGearSync:*'`
+
+Some certain features can be enabled separately
+
+`localStorage.debug = 'AeroGearSync:OfflineMutations*'`

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -30,17 +30,10 @@ import {
 To provide custom configuration to the client, the following options are available. If you wish, these are also available by using the `DataSyncConfig` interface from the SDK.
 
 ```javascript
-declare var window: any;
 
 let config: DataSyncConfig = {
-  httpUrl: "my-custom-url",
-  wsUrl: "my-custom-ws-url",
-  storage: window.localStorage,
-  conflictStrategy: strategies.diffMergeClientWins,
-  customLinkBuilder: customLinkBuilder,
-  networkStatus: customNetworkStatus,
-  mutationsQueueName: "offline-mutations-queue",
-  squashing: true
+  httpUrl: "http://localhost:4000/graphql",
+  wsUrl: "ws://localhost:4000/graphql",
 }
 ```
 
@@ -54,7 +47,7 @@ customLinkBuilder | Enables providing custom Apollo Link for processing requests
 networkStatus | Implementation of `NetworkStatus` Interface | See `WebNetworkStatus` and `CordovaNetworkStatus`
 mutationsQueueName | The name to store requests under in your offline queue | "offline-mutation-store"
 squashing | Whether or not you wish to squash mutations in your queue | true
-
+offlineQueueListener| listener that can be configured to receive events from offline queue
 
 # Creating a Client
 ```javascript
@@ -120,6 +113,7 @@ exampleQuery(...) @onlineOnly {
 ```
 
 ### Squashing Mutations
+
 Multiple changes performed on the same object ID and with the same mutation will automatically be joined by the AeroGear Sync SDK when your client is offline. This is beneficial as the client will not have to queue a large amount of mutations to replay once it returns online.
 
 #### Global Squashing
@@ -145,4 +139,4 @@ exampleMutation(...) @noSquash {
 ## Designing your types
 
 When designing your GraphQL schema types `id` field is always required.
-Library will perform business logic assumming that `id` field will be supplied and returned from server. Without this field some offline functionalities will not work properly.
+Library will perform business logic assuming that `id` field will be supplied and returned from server. Without this field some offline functionalities will not work properly.

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/datasync-js",
-  "version": "0.0.3-alpha",
+  "version": "0.0.4-alpha",
   "description": "Aero Gear DataSync SDK",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -2,6 +2,7 @@ import { ConflictResolutionStrategy } from "../conflicts";
 import { LinkChainBuilder } from "../links";
 import { PersistedData, PersistentStore } from "../PersistentStore";
 import { NetworkStatus } from "../offline";
+import { OfflineQueueListener } from "../offline/OfflineQueueListener";
 
 /**
  * Contains all configuration options required to initialize SDK
@@ -35,17 +36,23 @@ export interface DataSyncConfig {
   customLinkBuilder?: LinkChainBuilder;
 
   /**
-   * Network Status
+   * Inteface for detecting changes in network status
    */
   networkStatus?: NetworkStatus;
 
   /**
-   * The name of the queue to store offline mutations in
+   * The key used to store offline mutations
    */
   mutationsQueueName?: string | any;
 
   /**
-   * Whether or not to enable squashing of queries
+   * Whether or not to enable squashing offline mutations
    */
   mergeOfflineMutations?: boolean;
+
+  /**
+   * User provided listener that contains set of methods that can be used to detect
+   * when operations were added to queue
+   */
+  offlineQueueListener: OfflineQueueListener;
 }

--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -54,5 +54,5 @@ export interface DataSyncConfig {
    * User provided listener that contains set of methods that can be used to detect
    * when operations were added to queue
    */
-  offlineQueueListener: OfflineQueueListener;
+  offlineQueueListener?: OfflineQueueListener;
 }

--- a/packages/sync/src/createClient.ts
+++ b/packages/sync/src/createClient.ts
@@ -29,7 +29,7 @@ export const createClient = async (userConfig?: DataSyncConfig): Promise<Voyager
   const offlineMutationHandler = new OfflineRestoreHandler(apolloClient,
     storage,
     clientConfig.mutationsQueueName);
-  offlineMutationHandler.replayOfflineMutations();
+  await offlineMutationHandler.replayOfflineMutations();
   return apolloClient;
 };
 

--- a/packages/sync/src/links/LocalDirectiveFilterLink.ts
+++ b/packages/sync/src/links/LocalDirectiveFilterLink.ts
@@ -5,9 +5,9 @@ import {
 } from "apollo-link";
 import { hasDirectives, removeDirectivesFromDocument } from "apollo-utilities";
 import { localDirectivesArray, MUTATION_QUEUE_LOGGER } from "../config/Constants";
-import debug from "debug";
+import * as debug from "debug";
 
-export const logger = debug(MUTATION_QUEUE_LOGGER);
+export const logger = debug.default(MUTATION_QUEUE_LOGGER);
 
 export class LocalDirectiveFilterLink extends ApolloLink {
   private directiveRemovalConfig: any= [];

--- a/packages/sync/src/links/OfflineQueueLink.ts
+++ b/packages/sync/src/links/OfflineQueueLink.ts
@@ -13,10 +13,10 @@ import { localDirectives, MUTATION_QUEUE_LOGGER } from "../config/Constants";
 import { NetworkStatus, NetworkInfo } from "../offline";
 import { DataSyncConfig } from "../config";
 import { squashOperations } from "../offline/squashOperations";
-import debug from "debug";
+import * as debug from "debug";
 import { OfflineQueueListener } from "../offline/OfflineQueueListener";
 
-export const logger = debug(MUTATION_QUEUE_LOGGER);
+export const logger = debug.default(MUTATION_QUEUE_LOGGER);
 
 export interface OperationQueueEntry {
   operation: Operation;

--- a/packages/sync/src/links/OfflineQueueLink.ts
+++ b/packages/sync/src/links/OfflineQueueLink.ts
@@ -47,7 +47,7 @@ export class OfflineQueueLink extends ApolloLink {
   private readonly networkStatus?: NetworkStatus;
   private readonly operationFilter?: TYPE_MUTATION;
   private readonly mergeOfflineMutations?: boolean;
-  private readonly listener: OfflineQueueListener;
+  private readonly listener?: OfflineQueueListener;
   /**
    *
    * @param config configuration for queue
@@ -70,7 +70,7 @@ export class OfflineQueueLink extends ApolloLink {
       forward(operation).subscribe(observer);
     });
     this.opQueue = [];
-    if (this.listener.queueCleared) {
+    if (this.listener && this.listener.queueCleared) {
       this.listener.queueCleared();
     }
   }
@@ -107,7 +107,7 @@ export class OfflineQueueLink extends ApolloLink {
 
   private enqueue(entry: OperationQueueEntry) {
     logger("Adding new operation to offline queue");
-    if (this.listener.onOperationEnqueued) {
+    if (this.listener && this.listener.onOperationEnqueued) {
       this.listener.onOperationEnqueued(entry);
     }
     if (this.mergeOfflineMutations) {

--- a/packages/sync/src/offline/OfflineQueueListener.ts
+++ b/packages/sync/src/offline/OfflineQueueListener.ts
@@ -1,0 +1,19 @@
+import { OperationQueueEntry } from "../links/OfflineQueueLink";
+
+/**
+ * Interface for creating listeners for offline queue.
+ * Offline queue will add elements to queue when it's closed.
+ * This listener can be supplied to detect this events.
+ */
+export interface OfflineQueueListener {
+
+  /**
+   * Called when new operation is being added to offline queue
+   */
+  onOperationEnqueued?: (operation: OperationQueueEntry) => void;
+
+  /**
+   * Called when offline operation queue is cleared
+   */
+  queueCleared?: () => void;
+}

--- a/packages/sync/src/offline/OfflineRestoreHandler.ts
+++ b/packages/sync/src/offline/OfflineRestoreHandler.ts
@@ -3,9 +3,9 @@ import { NormalizedCacheObject } from "apollo-cache-inmemory";
 import { PersistentStore, PersistedData } from "../PersistentStore";
 import { OperationQueueEntry } from "../links/OfflineQueueLink";
 import { MUTATION_QUEUE_LOGGER } from "../config/Constants";
-import debug from "debug";
+import * as debug from "debug";
 
-export const logger = debug(MUTATION_QUEUE_LOGGER);
+export const logger = debug.default(MUTATION_QUEUE_LOGGER);
 /**
  * Class used to restore offline queue after page/application restarts.
  * It will trigger saved offline mutations using client to

--- a/packages/sync/src/offline/index.ts
+++ b/packages/sync/src/offline/index.ts
@@ -1,3 +1,4 @@
 export * from "./NetworkStatus";
 export * from "./WebNetworkStatus";
 export * from "./CordovaNetworkStatus";
+export * from "./OfflineQueueListener";


### PR DESCRIPTION
## Motivation
 
Allow to detect operations on queue in order to provide feedback for users and their UI. 
This simple listener can be extended over the time. For the moment we have:

- Detection of the element added to queue
- Detection of elements flushed from queue

This code will still be vulnerable to issues with RestoreHandler. 
I'm going to deal with this in separate PR as it's not as trivial as actual listener.
If you guys have idea about other methods that can be exposed let me know.

Verification will be possible on separate PR for ionic sample app- link soon.

## Notes

Since there is no implementation on our side we do not have unit tests for this particular feature.

## Verification

1. Please run example app using
https://github.com/aerogear/apollo-voyager-ionic-example/pull/5

2. Go offline
3. Add new item
4. See queue going to be zero