### PR TITLE
AEROGEAR-8027 - send client info when audit logging enabled

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,7 +13,4 @@ export * from "./Core";
 
 export * from "./PlatformUtils";
 
-export { MetricsBuilder } from "./metrics/MetricsBuilder";
-export { Metrics } from "./metrics/model/Metrics";
-export { AppMetrics } from "./metrics/model/AppMetrics";
-export { DeviceMetrics } from "./metrics/model/DeviceMetrics";
+export * from "./metrics";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,3 +12,8 @@ export * from "./config";
 export * from "./Core";
 
 export * from "./PlatformUtils";
+
+export { MetricsBuilder } from "./metrics/MetricsBuilder"
+export { Metrics } from "./metrics/model/Metrics"
+export { AppMetrics } from "./metrics/model/AppMetrics"
+export { DeviceMetrics } from "./metrics/model/DeviceMetrics"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,7 +13,7 @@ export * from "./Core";
 
 export * from "./PlatformUtils";
 
-export { MetricsBuilder } from "./metrics/MetricsBuilder"
-export { Metrics } from "./metrics/model/Metrics"
-export { AppMetrics } from "./metrics/model/AppMetrics"
-export { DeviceMetrics } from "./metrics/model/DeviceMetrics"
+export { MetricsBuilder } from "./metrics/MetricsBuilder";
+export { Metrics } from "./metrics/model/Metrics";
+export { AppMetrics } from "./metrics/model/AppMetrics";
+export { DeviceMetrics } from "./metrics/model/DeviceMetrics";

--- a/packages/core/src/metrics/MetricsBuilder.ts
+++ b/packages/core/src/metrics/MetricsBuilder.ts
@@ -7,9 +7,20 @@ import { CordovaAppMetrics } from "./platform/CordovaAppMetrics";
 import { CordovaDeviceMetrics } from "./platform/CordovaDeviceMetrics";
 declare var window: any;
 
+export interface Storage {
+  getItem(key: string): string | null;
+  setItem(key: string, data: string): void;
+}
+
 export class MetricsBuilder {
 
   public static readonly CLIENT_ID_KEY = "aerogear_metrics_client_key";
+
+  private storage: Storage;
+
+  constructor(storage?: Storage) {
+    this.storage = storage || window.localStorage;
+  }
 
   /**
    * Generates or gets mobile client id
@@ -25,12 +36,12 @@ export class MetricsBuilder {
     return clientId;
   }
 
-  public getSavedClientId(): string | undefined {
-    return window.localStorage.getItem(MetricsBuilder.CLIENT_ID_KEY);
+  public getSavedClientId(): string | null {
+    return this.storage.getItem(MetricsBuilder.CLIENT_ID_KEY);
   }
 
   public saveClientId(id: string): void {
-    window.localStorage.setItem(MetricsBuilder.CLIENT_ID_KEY, id);
+    this.storage.setItem(MetricsBuilder.CLIENT_ID_KEY, id);
   }
 
   /**

--- a/packages/core/src/metrics/MetricsBuilder.ts
+++ b/packages/core/src/metrics/MetricsBuilder.ts
@@ -1,0 +1,50 @@
+import console from "loglevel";
+import uuid from "uuid/v1";
+
+import { isMobileCordova } from "../PlatformUtils";
+import { Metrics } from "./model";
+import { CordovaAppMetrics } from "./platform/CordovaAppMetrics";
+import { CordovaDeviceMetrics } from "./platform/CordovaDeviceMetrics";
+declare var window: any;
+
+export class MetricsBuilder {
+
+  public static readonly CLIENT_ID_KEY = "aerogear_metrics_client_key";
+
+  /**
+   * Generates or gets mobile client id
+   */
+  public getClientId(): string {
+    let clientId = this.getSavedClientId();
+
+    if (!clientId) {
+      clientId = uuid();
+      this.saveClientId(clientId);
+    }
+
+    return clientId;
+  }
+
+  public getSavedClientId(): string | undefined {
+    return window.localStorage.getItem(MetricsBuilder.CLIENT_ID_KEY);
+  }
+
+  public saveClientId(id: string): void {
+    window.localStorage.setItem(MetricsBuilder.CLIENT_ID_KEY, id);
+  }
+
+  /**
+   * Builds array of default metrics objects that are sent to server on every request.
+   * Other platforms can override this method to provide custom behavior
+   */
+  public buildDefaultMetrics(): Metrics[] {
+    if (isMobileCordova()) {
+      return [new CordovaAppMetrics(), new CordovaDeviceMetrics()];
+    } else {
+      // No support of other platforms in default implementation.
+      // Please extend MetricsService class.
+      console.warn("Current platform is not supported by metrics.");
+      return [];
+    }
+  }
+}

--- a/packages/core/src/metrics/MetricsService.ts
+++ b/packages/core/src/metrics/MetricsService.ts
@@ -31,13 +31,16 @@ export class MetricsService {
       ? options.configuration
       : INSTANCE.getConfigByType(MetricsService.TYPE);
 
+    if (configuration && configuration.length > 0) {
+      this.configuration = configuration[0];
+    }
+
     this.builder = options && options.builder
       ? options.builder
       : new MetricsBuilder();
 
-    if (configuration && configuration.length > 0) {
+    if (this.configuration) {
       this.defaultMetrics = this.builder.buildDefaultMetrics();
-      this.configuration = configuration[0];
 
       this.publisher = options && options.publisher
         ? options.publisher

--- a/packages/core/src/metrics/index.ts
+++ b/packages/core/src/metrics/index.ts
@@ -1,3 +1,4 @@
 export * from "./MetricsService";
+export * from "./MetricsBuilder";
 export * from "./model";
 export * from "./publisher";

--- a/packages/core/src/metrics/platform/CordovaAppMetrics.ts
+++ b/packages/core/src/metrics/platform/CordovaAppMetrics.ts
@@ -11,6 +11,8 @@ export class CordovaAppMetrics implements Metrics {
 
   public identifier = "app";
 
+  private cachedPayload:any = undefined;
+
   /**
    * Get app metrics, to be called after deviceReady event.
    *
@@ -20,6 +22,10 @@ export class CordovaAppMetrics implements Metrics {
    */
   public collect(): Promise<AppMetrics> {
     return new Promise((resolve, reject) => {
+      if(this.cachedPayload){
+        return resolve(this.cachedPayload);
+      }
+
       if (!document) {
         return Promise.reject(new Error("Metrics not running in browser environment"));
       }
@@ -35,14 +41,14 @@ export class CordovaAppMetrics implements Metrics {
           app.getPackageName(),
           app.getVersionNumber()
         ])
-          .then(function(results) {
-            const payload = {
+          .then((results)=>{
+            this.cachedPayload = {
               appId: results[0],
               appVersion: results[1],
               sdkVersion: version,
               framework: "cordova"
             };
-            resolve(payload);
+            resolve(this.cachedPayload);
           });
       }, false);
     });

--- a/packages/core/src/metrics/platform/CordovaAppMetrics.ts
+++ b/packages/core/src/metrics/platform/CordovaAppMetrics.ts
@@ -11,7 +11,7 @@ export class CordovaAppMetrics implements Metrics {
 
   public identifier = "app";
 
-  private cachedPayload:any = undefined;
+  private cachedPayload: any = undefined;
 
   /**
    * Get app metrics, to be called after deviceReady event.
@@ -22,7 +22,7 @@ export class CordovaAppMetrics implements Metrics {
    */
   public collect(): Promise<AppMetrics> {
     return new Promise((resolve, reject) => {
-      if(this.cachedPayload){
+      if (this.cachedPayload) {
         return resolve(this.cachedPayload);
       }
 
@@ -41,7 +41,7 @@ export class CordovaAppMetrics implements Metrics {
           app.getPackageName(),
           app.getVersionNumber()
         ])
-          .then((results)=>{
+          .then((results) => {
             this.cachedPayload = {
               appId: results[0],
               appVersion: results[1],

--- a/packages/core/src/metrics/platform/CordovaDeviceMetrics.ts
+++ b/packages/core/src/metrics/platform/CordovaDeviceMetrics.ts
@@ -7,6 +7,8 @@ export class CordovaDeviceMetrics implements Metrics {
 
   public identifier = "device";
 
+  private cachedPayload:any = undefined;
+
   /**
    * Get device metrics, to be called after deviceReady event
    *
@@ -15,6 +17,10 @@ export class CordovaDeviceMetrics implements Metrics {
    */
   public collect(): Promise<DeviceMetrics> {
     return new Promise((resolve, reject) => {
+      if(this.cachedPayload){
+        return resolve(this.cachedPayload);
+      }
+
       if (!document) {
         return Promise.reject(new Error("Metrics not running in browser environment"));
       }
@@ -25,11 +31,12 @@ export class CordovaDeviceMetrics implements Metrics {
             "@aerogear/cordova-plugin-aerogear-metrics plugin is installed."
           );
         }
-        return resolve({
+        this.cachedPayload = {
           platform: window.device.platform.toLowerCase(),
           platformVersion: window.device.version,
           device: window.device.model
-        });
+        };
+        return resolve(this.cachedPayload);
       }, false);
     });
   }

--- a/packages/core/src/metrics/platform/CordovaDeviceMetrics.ts
+++ b/packages/core/src/metrics/platform/CordovaDeviceMetrics.ts
@@ -7,7 +7,7 @@ export class CordovaDeviceMetrics implements Metrics {
 
   public identifier = "device";
 
-  private cachedPayload:any = undefined;
+  private cachedPayload: any = undefined;
 
   /**
    * Get device metrics, to be called after deviceReady event
@@ -17,7 +17,7 @@ export class CordovaDeviceMetrics implements Metrics {
    */
   public collect(): Promise<DeviceMetrics> {
     return new Promise((resolve, reject) => {
-      if(this.cachedPayload){
+      if (this.cachedPayload) {
         return resolve(this.cachedPayload);
       }
 

--- a/packages/core/test/metrics/MetricsBuilderTest.ts
+++ b/packages/core/test/metrics/MetricsBuilderTest.ts
@@ -1,0 +1,71 @@
+import {assert} from "chai";
+import {MetricsBuilder} from "../../src/metrics";
+
+global.window = {};
+
+window.device = {};
+window.cordova = {
+
+  getAppVersion: {
+    getPackageName: () => {
+      console.info("");
+    },
+    getVersionNumber: () => {
+      console.info("");
+    }
+  }
+};
+
+const storage: any = { "aerogear_metrics_client_key": "" };
+
+const localStorage = {
+  getItem: (key: string): any => {
+    return storage[key];
+  },
+  setItem: (key: string, value: any): void => {
+    storage[key] = value;
+  }
+};
+
+describe("MetricsBuilder", () => {
+  let metricsBuilder: MetricsBuilder;
+
+  beforeEach(() => {
+    metricsBuilder = new MetricsBuilder(localStorage);
+    storage.aerogear_metrics_client_key = "";
+  });
+
+  describe("#getClientId", () => {
+
+    it("should generate a string client id", () => {
+      const id = metricsBuilder.getClientId();
+
+      assert.isString(id);
+    });
+
+    it("should save the client id when getting for first time", () => {
+      assert.equal(storage.aerogear_metrics_client_key, "");
+      const id = metricsBuilder.getClientId();
+
+      assert.equal(storage.aerogear_metrics_client_key, id);
+    });
+
+    it("should generate a new unique clientID if none is saved", () => {
+      const id = metricsBuilder.getClientId();
+      // Remove id from storage, as if it was a different device
+      storage.aerogear_metrics_client_key = "";
+      const newId = metricsBuilder.getClientId();
+
+      assert.notEqual(id, newId);
+    });
+
+    it("should return the same clientID after the first time", () => {
+      const id = metricsBuilder.getClientId();
+      const newId = metricsBuilder.getClientId();
+
+      assert.equal(id, newId);
+    });
+
+  });
+
+});

--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -55,4 +55,9 @@ export interface DataSyncConfig {
    * when operations were added to queue
    */
   offlineQueueListener?: OfflineQueueListener;
+
+  /**
+   * If set to true, GraphGL requests will include some additional data to audit log in the server side.
+   */
+  auditLogging?: boolean;
 }

--- a/packages/sync/src/config/SyncConfig.ts
+++ b/packages/sync/src/config/SyncConfig.ts
@@ -20,6 +20,7 @@ export class SyncConfig implements DataSyncConfig {
   public storage?: PersistentStore<PersistedData>;
   public mutationsQueueName = "offline-mutation-store";
   public mergeOfflineMutations = true;
+  public auditLogging = false;
 
   public networkStatus = (isMobileCordova()) ? new CordovaNetworkStatus() : new WebNetworkStatus();
 

--- a/packages/sync/src/createClient.ts
+++ b/packages/sync/src/createClient.ts
@@ -20,7 +20,7 @@ export type VoyagerClient = ApolloClient<NormalizedCacheObject>;
 export const createClient = async (userConfig?: DataSyncConfig): Promise<VoyagerClient> => {
   const clientConfig = extractConfig(userConfig);
   const { cache } = await buildCachePersistence(clientConfig);
-  const link = buildLink(clientConfig);
+  const link = await buildLink(clientConfig);
   const apolloClient = new ApolloClient({
     link,
     cache

--- a/packages/sync/src/links/AuditLoggingLink.ts
+++ b/packages/sync/src/links/AuditLoggingLink.ts
@@ -1,21 +1,20 @@
 import { NextLink, Operation } from "apollo-link/src/types";
 import { ApolloLink } from "apollo-link";
 
-
 export class AuditLoggingLink extends ApolloLink {
 
-  private clientId:string;
-  private metricsPayload:any;
+  private clientId: string;
+  private metricsPayload: any;
 
-  constructor(clientId:string, metricsPayload:any){
+  constructor(clientId: string, metricsPayload: any) {
     super();
     this.clientId = clientId;
     this.metricsPayload = metricsPayload;
   }
 
-  public request (operation:Operation, forward?: NextLink) {
+  public request(operation: Operation, forward?: NextLink) {
     if (!operation.extensions) {
-      operation.extensions = {}
+      operation.extensions = {};
     }
 
     operation.extensions.metrics = {
@@ -24,7 +23,7 @@ export class AuditLoggingLink extends ApolloLink {
       data: this.metricsPayload
     };
 
-    if(!forward){
+    if (!forward) {
       return null;
     }
     return forward(operation);

--- a/packages/sync/src/links/AuditLoggingLink.ts
+++ b/packages/sync/src/links/AuditLoggingLink.ts
@@ -1,0 +1,32 @@
+import { NextLink, Operation } from "apollo-link/src/types";
+import { ApolloLink } from "apollo-link";
+
+
+export class AuditLoggingLink extends ApolloLink {
+
+  private clientId:string;
+  private metricsPayload:any;
+
+  constructor(clientId:string, metricsPayload:any){
+    super();
+    this.clientId = clientId;
+    this.metricsPayload = metricsPayload;
+  }
+
+  public request (operation:Operation, forward?: NextLink) {
+    if (!operation.extensions) {
+      operation.extensions = {}
+    }
+
+    operation.extensions.metrics = {
+      clientId: this.clientId,
+      timestamp: new Date().getTime(),
+      data: this.metricsPayload
+    };
+
+    if(!forward){
+      return null;
+    }
+    return forward(operation);
+  }
+}

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -36,11 +36,11 @@ export const defaultLinkBuilder: LinkChainBuilder =
       links = [localLink, httpLink];
     }
 
-    if(config.auditLogging){
-      const metricsBuilder:MetricsBuilder = new MetricsBuilder();
-      const metricsPayload: {[key:string]:any} = {};
+    if (config.auditLogging) {
+      const metricsBuilder: MetricsBuilder = new MetricsBuilder();
+      const metricsPayload: {[key: string]: any} = {};
       const metrics = metricsBuilder.buildDefaultMetrics();
-      for(let metric of metrics){
+      for (const metric of metrics) {
         metricsPayload[metric.identifier] = await metric.collect();
       }
       const auditLoggingLink = new AuditLoggingLink(metricsBuilder.getClientId(), metricsPayload);


### PR DESCRIPTION
With this PR, GraphQL requests now have the client info (client id, app info, device info) in the extensions part of a request. That's only done when auditLogging is enabled.
The code that's collecting the client info is made reusable.

### Verification instructions:

*NOTE*: Device/app/client info can't be collected in the browser. You need to verify using Cordova.

#### 1. Voyager server

Get https://github.com/aerogear/apollo-voyager-server/pull/28

Execute 
```
npm install
npm run bootstrap
npm run compile
node examples/auditLogging/server.js
```

This will start the audit logging example where some audit logs are written to stdout with every request.

#### 2. JS SDK

Gotta build and link the JS SDK.

Get this PR (https://github.com/aerogear/aerogear-js-sdk/pull/195)

Execute
```
npm install
npm run bootstrap
npm run build
npm run link
# npm link fucks up some stuff. gotta run bootstrap again
npm run bootstrap 
```

#### 3. Sample app

Get https://github.com/aliok/sync-ionic-example-auditing
Edit `src/app/tab1/tab1.page.ts` and change the ip with your local ip.
```
const uri = 'http://192.168.1.111:4000/graphql';
```

Execute
```
npm link @aerogear/datasync-js
ionic build

# in my machine ionic cordova run android doesn't work. so I do it manually
ionic cordova build android
adb install platforms/android/app/build/outputs/apk/debug/app-debug.apk
```

#### 4. Final steps

When the Cordova app starts, you will see a button called "Voyager" at the top.
Click on that one.
That button will initiate a Graphql request. And in this sample app, auditLogging=true is passed to JS SDK.

You will see some logs in stdout in Voyager server similar to this one (important part is the `clientInfo` field):
```json
{
  "level": 30,
  "time": 1545385687476,
  "pid": 11889,
  "hostname": "localhost.localdomain",
  "tag": "AUDIT",
  "msg": "",
  "operationType": "query",
  "fieldName": "hello",
  "parentTypeName": "Query",
  "path": "hello",
  "success": true,
  "arguments": {},
  "clientInfo": {
    "clientId": "848d2a10-0505-11e9-888f-8d166149101a",
    "timestamp": 1545385686843,
    "data": {
      "app": {
        "appId": "io.ionic.starter",
        "appVersion": "0.0.1",
        "sdkVersion": "2.0.0",
        "framework": "cordova"
      },
      "device": {
        "platform": "android",
        "platformVersion": "9",
        "device": "Android SDK built for x86_64"
      }
    }
  },
  "v": 1
}
```


