### PR TITLE
fix: Move core to be in peerDependencies

### DIFF
--- a/docs/contrib/releng.adoc
+++ b/docs/contrib/releng.adoc
@@ -90,6 +90,13 @@ git commit -am 'release version x.y.z'
 
 Once your changes have been merged to master, you can continue and release to npm.
 
+=== Updating core peer dependency
+
+Each service package currently depends on core package using peerDependency.
+This dependency is not updated using automatic release scripts.
+If you have made any changes in core that are breaking API `peerDependency`
+needs to be changed manually for those packages.
+
 === How to Release
 
 To kick off a release to npm, simply link:https://help.github.com/articles/creating-releases/[Create a Release] in Github. **You must use the exact tag you used earlier** or the release will fail.

--- a/lerna.json
+++ b/lerna.json
@@ -8,5 +8,5 @@
       "exact": true
     }
   },
-  "version": "2.1.0-rc1"
+  "version": "2.1.0-rc2"
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/app",
-  "version": "2.1.0-rc1",
+  "version": "2.1.0-rc2",
   "description": "Aero Gear SDK application module",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -31,6 +31,6 @@
     "nyc": "^11.7.1"
   },
   "dependencies": {
-    "@aerogear/core": "2.1.0-rc1"
+    "@aerogear/core": "2.1.0-rc2"
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -49,6 +49,7 @@
     "branches": 80
   },
   "devDependencies": {
+    "@aerogear/core": "2.1.0",
     "@types/chai": "4.1.2",
     "@types/chai-as-promised": "7.1.0",
     "@types/loglevel": "^1.5.3",
@@ -72,6 +73,6 @@
     "url": "^0.11.0"
   },
   "peerDependencies": {
-    "@aerogear/core": ">2.0.1"
+    "@aerogear/core": ">2.1.0"
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -67,9 +67,11 @@
     "typescript": "^2.8.1"
   },
   "dependencies": {
-    "@aerogear/core": "2.1.0-rc1",
     "keycloak-js": "^4.8.3",
     "loglevel": "^1.6.1",
     "url": "^0.11.0"
+  },
+  "peerDependencies": {
+    "@aerogear/core": ">2.0.1"
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/auth",
-  "version": "2.1.0-rc1",
+  "version": "2.1.0-rc2",
   "description": "JavaScript Auth module for AeroGear services",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -49,7 +49,7 @@
     "branches": 80
   },
   "devDependencies": {
-    "@aerogear/core": "2.1.0",
+    "@aerogear/core": "2.1.0-rc2",
     "@types/chai": "4.1.2",
     "@types/chai-as-promised": "7.1.0",
     "@types/loglevel": "^1.5.3",
@@ -73,6 +73,6 @@
     "url": "^0.11.0"
   },
   "peerDependencies": {
-    "@aerogear/core": ">2.1.0"
+    "@aerogear/core": ">2.0.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/core",
-  "version": "2.1.0",
+  "version": "2.1.0-rc2",
   "description": "JavaScript Core SDK for AeroGear services",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/core",
-  "version": "2.1.0-rc1",
+  "version": "2.1.0",
   "description": "JavaScript Core SDK for AeroGear services",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/packages/metrics-cordova/package.json
+++ b/packages/metrics-cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/cordova-plugin-aerogear-metrics",
-  "version": "2.1.0-rc1",
+  "version": "2.1.0-rc2",
   "description": "Cordova plugin for AeroGear Metrics",
   "cordova": {
     "id": "cordova-plugin-aerogear-metrics",

--- a/packages/push-cordova/package.json
+++ b/packages/push-cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/cordova-plugin-aerogear-push",
-  "version": "2.1.0-rc1",
+  "version": "2.1.0-rc2",
   "description": "Cordova plugin for AeroGear Push Notifications",
   "cordova": {
     "id": "cordova-plugin-aerogear-push",

--- a/packages/push/package.json
+++ b/packages/push/package.json
@@ -34,7 +34,9 @@
     "nyc": "^11.7.1"
   },
   "dependencies": {
-    "@aerogear/core": "2.1.0-rc1",
     "axios": "^0.18.0"
+  },
+  "peerDependencies": {
+    "@aerogear/core": ">2.0.1"
   }
 }

--- a/packages/push/package.json
+++ b/packages/push/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/aerogear/aerogear-js-sdk#readme",
   "devDependencies": {
+    "@aerogear/core": "2.1.0",
     "@types/chai": "^4.1.3",
     "chai": "^4.1.2",
     "mocha": "^5.1.1",
@@ -37,6 +38,6 @@
     "axios": "^0.18.0"
   },
   "peerDependencies": {
-    "@aerogear/core": ">2.0.1"
+    "@aerogear/core": ">2.1.0"
   }
 }

--- a/packages/push/package.json
+++ b/packages/push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/push",
-  "version": "2.1.0-rc1",
+  "version": "2.1.0-rc2",
   "description": "AeroGear Unified Push Registration SDK",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/aerogear/aerogear-js-sdk#readme",
   "devDependencies": {
-    "@aerogear/core": "2.1.0",
+    "@aerogear/core": "2.1.0-rc2",
     "@types/chai": "^4.1.3",
     "chai": "^4.1.2",
     "mocha": "^5.1.1",
@@ -38,6 +38,6 @@
     "axios": "^0.18.0"
   },
   "peerDependencies": {
-    "@aerogear/core": ">2.1.0"
+    "@aerogear/core": ">2.0.1"
   }
 }

--- a/packages/security-cordova/package.json
+++ b/packages/security-cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/cordova-plugin-aerogear-security",
-  "version": "2.1.0-rc1",
+  "version": "2.1.0-rc2",
   "description": "Cordova plugin for self defence checks for Android and iOS devices.",
   "cordova": {
     "id": "cordova-plugin-aerogear-security",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/security",
-  "version": "2.1.0-rc1",
+  "version": "2.1.0-rc2",
   "description": "AeroGear Services JavaScript Security SDK",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -26,15 +26,13 @@
   },
   "homepage": "https://github.com/aerogear/aerogear-js-sdk#readme",
   "devDependencies": {
-    "@aerogear/core": "2.1.0",
+    "@aerogear/core": "2.1.0-rc2",
     "@types/chai": "^4.1.3",
     "chai": "^4.1.2",
     "mocha": "^5.1.1",
     "nyc": "^11.7.1"
   },
-  "dependencies": {
-  },
   "peerDependencies": {
-    "@aerogear/core": ">2.1.0"
+    "@aerogear/core": ">2.0.1"
   }
 }

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -32,6 +32,8 @@
     "nyc": "^11.7.1"
   },
   "dependencies": {
-    "@aerogear/core": "2.1.0-rc1"
+  },
+  "peerDependencies": {
+    "@aerogear/core": ">2.0.1"
   }
 }

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/aerogear/aerogear-js-sdk#readme",
   "devDependencies": {
+    "@aerogear/core": "2.1.0",
     "@types/chai": "^4.1.3",
     "chai": "^4.1.2",
     "mocha": "^5.1.1",
@@ -34,6 +35,6 @@
   "dependencies": {
   },
   "peerDependencies": {
-    "@aerogear/core": ">2.0.1"
+    "@aerogear/core": ">2.1.0"
   }
 }

--- a/packages/sync-cordova/package.json
+++ b/packages/sync-cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/cordova-plugin-aerogear-sync",
-  "version": "2.1.0-rc1",
+  "version": "2.1.0-rc2",
   "description": "Cordova plugin for AeroGear Sync",
   "cordova": {
     "id": "cordova-plugin-aerogear-sync",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -31,6 +31,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@aerogear/core": "2.1.0",
     "@types/chai": "^4.1.3",
     "@types/debug": "0.0.31",
     "@types/graphql": "^14.0.3",
@@ -43,7 +44,7 @@
     "typescript": "^3.1.6"
   },
   "peerDependencies": {
-    "@aerogear/core": ">2.0.1"
+    "@aerogear/core": ">2.1.0"
   },
   "dependencies": {
     "apollo-cache-inmemory": "1.3.9",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -31,7 +31,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@aerogear/core": "2.1.0-rc1",
     "@types/chai": "^4.1.3",
     "@types/debug": "0.0.31",
     "@types/graphql": "^14.0.3",
@@ -44,7 +43,7 @@
     "typescript": "^3.1.6"
   },
   "peerDependencies": {
-    "@aerogear/core": ">2.0.0"
+    "@aerogear/core": ">2.0.1"
   },
   "dependencies": {
     "apollo-cache-inmemory": "1.3.9",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/datasync-js",
-  "version": "2.1.0-rc1",
+  "version": "2.1.0-rc2",
   "description": "AeroGear Apollo GraphQL Voyager client",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -31,7 +31,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@aerogear/core": "2.1.0",
+    "@aerogear/core": "2.1.0-rc2",
     "@types/chai": "^4.1.3",
     "@types/debug": "0.0.31",
     "@types/graphql": "^14.0.3",
@@ -44,7 +44,7 @@
     "typescript": "^3.1.6"
   },
   "peerDependencies": {
-    "@aerogear/core": ">2.1.0"
+    "@aerogear/core": ">2.0.1"
   },
   "dependencies": {
     "apollo-cache-inmemory": "1.3.9",


### PR DESCRIPTION
## Motivation

Core package is used as singleton and when having more than single instance of core app config will stop working. While this is only temporary fix for the invalid architecture it will provide cleaner way to manage core<> app dependency.

How things will work now:
- App will be required to configure entire platform and setup metrics
- Each individual package will be relying on the core provided in app dependency.

Eventually we can map app package to core and let it be used inside every SDK - however this will affect documentation and end user API so not sure if we are ok with this move.

EDIT:

Actually core.init and app init are the same so we could do that if you guys think this is the way to go.
 