### PR TITLE
Allow updates on items created while offline

### DIFF
--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -314,13 +314,9 @@ appear instantly in the application UI. SDK provides helper method to work with 
 
 Users can detect if the provided data is optimistic response by checking `optimisticResponse` flag is set to true.
 
-> Note: pending changes created by helper are read only. Performing any additional
-operations on pending objects will result in error due to fact that next changes will be missing actual ID that can be created on server side.
-
-
 ### Mapping Client and Server ID for Optimistic Reponses
 
-When using `OptimisticReponse` helper from SDK specific mutations that create new element response is going to have client side generated id. Subsequent edits for this objects will also refer to this id. When becoming online, all offline changes are going to be performed in specific order invalidating client side id for subsequent edits. If edits for objects created when offline are required, developers need to support a way to map them in their resolvers.
+When using `OptimisticReponse` helper from SDK specific mutations that create new element response is going to have client side generated id. Subsequent edits for this objects will also refer to this id. When becoming online, all offline changes are going to be performed in specific order updating client side id with id returned from server for subsequent edits.
 
 ## Listening to the offline queue events
 

--- a/packages/sync/integration_test/test/offline.test.js
+++ b/packages/sync/integration_test/test/offline.test.js
@@ -182,7 +182,7 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
     });
   });
 
-  describe.skip('create then update item while offline', function() {
+  describe('create then update item while offline', function() {
     it('should succeed', async function() {
       let task;
       

--- a/packages/sync/src/cache/createOptimisticResponse.ts
+++ b/packages/sync/src/cache/createOptimisticResponse.ts
@@ -48,6 +48,7 @@ export const createOptimisticResponse =
     };
     if (addId) {
       optimisticResponse[operation][idField] = generateId();
+      optimisticResponse[operation].__optimisticId = true;
     }
 
     return optimisticResponse;

--- a/packages/sync/src/cache/createOptimisticResponse.ts
+++ b/packages/sync/src/cache/createOptimisticResponse.ts
@@ -1,7 +1,13 @@
 
+const CLIENT_ID_PREFIX = "client:";
+
+export const hasClientGeneratedId = (optimisticResponse: any, operationName: string) => {
+  return optimisticResponse[operationName].id.startsWith(CLIENT_ID_PREFIX);
+};
+
 // Helper method for ID generation ()
 const generateId = (length = 8) => {
-  let result = "client:";
+  let result = CLIENT_ID_PREFIX;
   const chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
   for (let i = length; i > 0; i -= 1) {

--- a/packages/sync/src/cache/createOptimisticResponse.ts
+++ b/packages/sync/src/cache/createOptimisticResponse.ts
@@ -1,7 +1,7 @@
 
 // Helper method for ID generation ()
 const generateId = (length = 8) => {
-  let result = "";
+  let result = "client:";
   const chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
   for (let i = length; i > 0; i -= 1) {
@@ -48,7 +48,6 @@ export const createOptimisticResponse =
     };
     if (addId) {
       optimisticResponse[operation][idField] = generateId();
-      optimisticResponse[operation].__optimisticId = true;
     }
 
     return optimisticResponse;

--- a/packages/sync/src/links/OfflineQueueLink.ts
+++ b/packages/sync/src/links/OfflineQueueLink.ts
@@ -72,7 +72,6 @@ export class OfflineQueueLink extends ApolloLink {
         forward(operation).subscribe({
           next: result => {
             this.updateIds(opEntry, result);
-            this.storage.setItem(this.key, JSON.stringify(this.opQueue));
             if (observer.next) { observer.next(result); }
           },
           error: error => {
@@ -178,7 +177,7 @@ export class OfflineQueueLink extends ApolloLink {
   ): void {
     const operation = operationEntry.operation;
     const optimisticResponse = operationEntry.optimisticResponse;
-    if (optimisticResponse && optimisticResponse[operation.operationName].__optimisticId) {
+    if (optimisticResponse && optimisticResponse[operation.operationName].id.startsWith('client:')) {
       const optimisticId = optimisticResponse[operation.operationName].id;
       this.opQueue.forEach(({ operation: op }) => {
         if (op.variables.id === optimisticId && result.data) {

--- a/packages/sync/src/links/OfflineQueueLink.ts
+++ b/packages/sync/src/links/OfflineQueueLink.ts
@@ -177,7 +177,7 @@ export class OfflineQueueLink extends ApolloLink {
   ): void {
     const operation = operationEntry.operation;
     const optimisticResponse = operationEntry.optimisticResponse;
-    if (optimisticResponse && optimisticResponse[operation.operationName].id.startsWith('client:')) {
+    if (optimisticResponse && optimisticResponse[operation.operationName].id.startsWith("client:")) {
       const optimisticId = optimisticResponse[operation.operationName].id;
       this.opQueue.forEach(({ operation: op }) => {
         if (op.variables.id === optimisticId && result.data) {


### PR DESCRIPTION
### Description

https://issues.jboss.org/browse/AEROGEAR-8444

Extracted from https://github.com/aerogear/aerogear-js-sdk/pull/213.

Allow updates on items created while offline. When back online, operations in mutations queue are send one by one (waiting for previous one to finish). If there was optimistic id for the operation, and server returns real id, next operations with this optimistic id in queue are updated with this new id.

This will only work until client is re-initialized - `replayOfflineMutations` does not have this change. https://github.com/jhellar/aerogear-js-sdk/pull/1 enables this also for `replayOfflineMutations`.

#### Verification steps

1. `npm link` those changes to `apollo-voyager-ionic-example` app
2. go offline
3. create item then make some updates on it
4. go back online
5. when offline updates are performed you should still see the updated item