### PR TITLE
Enqueue incoming mutations while processing offline queue

### DIFF
--- a/packages/sync/src/links/OfflineQueueLink.ts
+++ b/packages/sync/src/links/OfflineQueueLink.ts
@@ -92,7 +92,7 @@ export class OfflineQueueLink extends ApolloLink {
   }
 
   public request(operation: Operation, forward: NextLink) {
-    if (this.isOpen) {
+    if (this.isOpen && this.opQueue.length === 0) {
       logger("Forwarding request");
       return forward(operation);
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/aerogear/aerogear-js-sdk/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

https://issues.jboss.org/browse/AEROGEAR-8453

If there is a lot of operations in offline queue, client is going back online, then for example if client will update item (created while offline) while queue is being processed, it can happen that this update operation will happen before the create operation, so it will fail.

To prevent this, operations should be enqueued when processing queue, even if queue is open.

