### PR TITLE
fix: Disable garbage collecting of old cache entries.

### DIFF
--- a/packages/sync/src/createClient.ts
+++ b/packages/sync/src/createClient.ts
@@ -54,7 +54,9 @@ async function buildCachePersistence(clientConfig: DataSyncConfig) {
   const cache = new InMemoryCache();
   await persistCache({
     cache,
-    storage: clientConfig.storage as PersistentStore<PersistedData>
+    storage: clientConfig.storage as PersistentStore<PersistedData>,
+    maxSize: false,
+    debug: false
   });
   return { cache };
 }


### PR DESCRIPTION
## Motivation

Cache by default will start removing data after reaching 1MB. 
This change disables that by default. It also removes debug statements to make cache much smaller in size.