### PR TITLE
Added ability to pass a resolver object

### DIFF
--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -174,7 +174,7 @@ When collision is detected it can be handled on both server or client.
 
 See Voyager Server documentation for information about writing conflicts for the server.
 
-### Working with plugable conflict implementations
+### Working with pluggable conflict implementations
 
 Plugable conflict resolution allows developers to define way to determine how conflicts are detected and handled.
 Conflict resolution can be fully controlled by server side implementation.

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -227,23 +227,24 @@ Custom strategies can be used also to provide different resolution strategy for 
 
 
 ```javascript
-let clientWins = (operation, serverData, clientData) => {
-  if(operation === 'updateUser'){
-      delete clientData.socialKey
-      return Object.assign(serverData, clientData);
-  }
-  else return clientWins(operation, serverData, clientData);
+let updateUserConflictResolver = (serverData, clientData) => {
+    delete clientData.socialKey
+    return Object.assign(serverData, clientData);
+};
+
+let updateTaskConflictResolver = (serverData, clientData) => {
+    ...
 };
 ```
 
 > Note: Client strategies will work only when specific server side resolver explicitly states that conflicts should be fixed on the client. Client strategy will be ignored when conflict is resolved on the server.
 
 To use strategy pass it as argument to conflictStrategy in your config object:
-
+ 
 ```javascript
 let config = {
 ...
-  conflictStrategy: clientWins
+  conflictStrategy: {"TaskUpdated": updateTaskConflictResolver, "UserUpdated": updateUserConflictResolver}
 ...
 }
 ```

--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -1,4 +1,4 @@
-import { ConflictResolutionStrategy, IResolver } from "../conflicts/ConflictResolutionStrategy";
+import { ConflictResolutionStrategy, ConflictResolutionStrategies } from "../conflicts/ConflictResolutionStrategy";
 import { PersistedData, PersistentStore } from "../PersistentStore";
 import { NetworkStatus } from "../offline";
 import { OfflineQueueListener } from "../offline";
@@ -62,11 +62,6 @@ export interface DataSyncConfig {
   auditLogging?: boolean;
 
   /**
-   * The conflict resolution strategy your client should use. By default it takes client version
-   */
-  conflictStrategy?: ConflictResolutionStrategy;
-
-  /**
    * Interface that defines how object state is progressed
    */
   conflictStateProvider?: NextState;
@@ -81,5 +76,8 @@ export interface DataSyncConfig {
    */
   openShiftConfig?: ConfigurationService;
 
-  resolvers?: IResolver;
+  /**
+   * The conflict resolution strategy your client should use. By default it takes client version.
+   */
+  conflictStrategy?: ConflictResolutionStrategy | ConflictResolutionStrategies;
 }

--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -1,4 +1,4 @@
-import { ConflictResolutionStrategy } from "../conflicts/ConflictResolutionStrategy";
+import { ConflictResolutionStrategy, IResolver } from "../conflicts/ConflictResolutionStrategy";
 import { PersistedData, PersistentStore } from "../PersistentStore";
 import { NetworkStatus } from "../offline";
 import { OfflineQueueListener } from "../offline";
@@ -80,4 +80,6 @@ export interface DataSyncConfig {
    * OpenShift specific configuration
    */
   openShiftConfig?: ConfigurationService;
+
+  resolvers?: IResolver;
 }

--- a/packages/sync/src/conflicts/ConflictResolutionStrategy.ts
+++ b/packages/sync/src/conflicts/ConflictResolutionStrategy.ts
@@ -10,3 +10,8 @@ import { ConflictResolutionData } from "./ConflictResolutionData";
  */
 export type ConflictResolutionStrategy =
   (operationName: string, server: ConflictResolutionData, client: ConflictResolutionData) => ConflictResolutionData;
+
+export interface IResolver {
+ [id: string]: (server: ConflictResolutionData,
+                client: ConflictResolutionData) => ConflictResolutionData;
+}

--- a/packages/sync/src/conflicts/ConflictResolutionStrategy.ts
+++ b/packages/sync/src/conflicts/ConflictResolutionStrategy.ts
@@ -11,7 +11,14 @@ import { ConflictResolutionData } from "./ConflictResolutionData";
 export type ConflictResolutionStrategy =
   (operationName: string, server: ConflictResolutionData, client: ConflictResolutionData) => ConflictResolutionData;
 
-export interface IResolver {
- [id: string]: (server: ConflictResolutionData,
-                client: ConflictResolutionData) => ConflictResolutionData;
+/**
+ * Interface for conflict handlers that can be used to resolve conflicts.
+ * It is modeled as a Dictionary where the key is the operation name and the value is the conflict resolver function.
+ * The parameters of the conflict resolver functions are:
+ * @param server - server data
+ * @param client - client data
+ */
+export interface ConflictResolutionStrategies {
+ [operationName: string]: (server: ConflictResolutionData,
+                           client: ConflictResolutionData) => ConflictResolutionData;
 }


### PR DESCRIPTION
# Motivation
Issue: [AEROGEAR-8382](https://issues.jboss.org/browse/AEROGEAR-8382) - #198 

# Description

- Added a new `ConflictResolutionStrategies` interface that allows passing pairs of `operationName` and `resolver` function.
- Added ability to work with both the old way (one function for all the operations) and the new way (one function for each operation)

# Activity

- [x] Add the new function
- [x] Update the readme
- [x] Update doc in comments