### PR TITLE
fix:initialise the config object correctly

### DIFF
--- a/packages/sync/src/createClient.ts
+++ b/packages/sync/src/createClient.ts
@@ -54,9 +54,9 @@ export const createClient = async (userConfig?: DataSyncConfig): Promise<Voyager
  */
 function extractConfig(userConfig: DataSyncConfig | undefined) {
   const config = new SyncConfig();
-  config.applyPlatformConfig(config);
   const clientConfig = config.merge(userConfig);
-  config.validate(config);
+  config.applyPlatformConfig(clientConfig);
+  config.validate(clientConfig);
   return clientConfig;
 }
 


### PR DESCRIPTION
### Description

Saw the following error when I try to run the ionic-showcase app against an openshift cluster:

```
Error: Missing server URL
    at new ConfigError (ConfigError.js:22)
    at SyncConfig.push../node_modules/@aerogear/voyager-client/dist/config/SyncConfig.js.SyncConfig.validate (SyncConfig.js:50)
    at extractConfig (createClient.js:93)
    at Object.<anonymous> (createClient.js:59)
    at step (createClient.js:32)
    at Object.next (createClient.js:13)
    at createClient.js:7
    at new ZoneAwarePromise (zone.js:910)
    at push../node_modules/@aerogear/voyager-client/dist/createClient.js.__awaiter (createClient.js:3)
    at push../node_modules/@aerogear/voyager-client/dist/createClient.js.exports.createClient (createClient.js:54)
```

This PR fix the issue. It always use the urls from mobile-services.json file first, then fall back to `localhost` if no url specified.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works

