### PR TITLE
BREAKING: Remove check-sso option as default param

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -37,9 +37,6 @@ export class Auth {
    * @returns A promise to set functions to be invoked on success or error.
    */
   public init(initOptions: KeycloakInitOptions): Promise<boolean> {
-    if (!initOptions.onLoad) {
-      initOptions.onLoad = "check-sso";
-    }
     return new Promise((resolve, reject) => {
       return this.auth.init(initOptions).error(reject).success(resolve);
     });


### PR DESCRIPTION
## Motivation

Default value makes no sense and prevents from initializing keycloak without login operation.
Our default should be just empty/undefined value