### PR TITLE
fix: changed link flow to fix local directives

### DIFF
--- a/packages/sync/integration_test/test/offline.test.js
+++ b/packages/sync/integration_test/test/offline.test.js
@@ -24,7 +24,7 @@ const newClient = async (clientOptions = {}) => {
   return await createClient(config);
 };
 
-describe('AeroGear Apollo GraphQL Voyager client', function() {
+describe('AeroGear Apollo GraphQL Voyager client', function () {
 
   this.timeout(1000);
 
@@ -42,30 +42,30 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
 
   let client, networkStatus, store;
 
-  before('start server', async function() {
+  before('start server', async function () {
     await server.start();
   });
 
-  beforeEach('reset server', async function() {
+  beforeEach('reset server', async function () {
     await server.reset();
   });
 
-  beforeEach('create client', async function() {
+  beforeEach('create client', async function () {
     networkStatus = newNetworkStatus(false);
     store = new TestStore();
     client = await newClient({ networkStatus, storage: store, mutationsQueueName });
   });
 
-  describe('save mutation to offlineMutationStore while offline', function() {
+  describe('save mutation to offlineMutationStore while offline', function () {
 
-    it('should succeed', function() {
+    it('should succeed', function () {
       client.mutate({
         mutation: ADD_TASK,
         variables: newTask
       });
-  
+
       const offlineMutationStore = JSON.parse(store.getItem(mutationsQueueName));
-  
+
       expect(offlineMutationStore).to.exist;
       expect(offlineMutationStore[0]).to.exist;
       expect(offlineMutationStore[0].operation).to.exist;
@@ -76,16 +76,16 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
 
   });
 
-  describe('send mutation when going back online', function() {
+  describe('send mutation when going back online', function () {
 
-    beforeEach('prepare data', function() {
+    beforeEach('prepare data', function () {
       client.mutate({
         mutation: ADD_TASK,
         variables: newTask
       });
     });
 
-    it('should succeed', async function() {
+    it('should succeed', async function () {
       networkStatus.setOnline(true);
 
       await waitFor(() => JSON.parse(store.getItem(mutationsQueueName)).length === 0);
@@ -102,11 +102,11 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
 
   });
 
-  describe('save more mutations while offline', function() {
+  describe('save more mutations while offline', function () {
 
     let task;
 
-    beforeEach('prepare data', async function() {
+    beforeEach('prepare data', async function () {
       networkStatus.setOnline(true);
 
       const response = await client.mutate({
@@ -119,7 +119,7 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
       networkStatus.setOnline(false);
     });
 
-    it('should succeed', async function() {
+    it('should succeed', async function () {
       const variables = { ...updatedTask, id: task.id, version: task.version };
 
       client.mutate({
@@ -141,9 +141,9 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
     });
   });
 
-  describe('send more mutations when back online', function() {
+  describe('send more mutations when back online', function () {
 
-    beforeEach('prepare data', async function() {
+    beforeEach('prepare data', async function () {
       networkStatus.setOnline(true);
 
       const response = await client.mutate({
@@ -167,7 +167,7 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
       });
     });
 
-    it('should succeed', async function() {
+    it('should succeed', async function () {
       networkStatus.setOnline(true);
 
       await waitFor(() => JSON.parse(store.getItem(mutationsQueueName)).length === 0);
@@ -182,10 +182,10 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
     });
   });
 
-  describe('create then update item while offline', function() {
-    it('should succeed', async function() {
+  describe('create then update item while offline', function () {
+    it('should succeed', async function () {
       let task;
-      
+
       client.mutate({
         mutation: ADD_TASK,
         variables: newTask,
@@ -215,8 +215,8 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
     });
   });
 
-  describe('create then update item while offline then replaying mutations', function() {
-    it('should succeed', async function() {
+  describe('create then update item while offline then replaying mutations', function () {
+    it('should succeed', async function () {
       let task;
 
       client.mutate({
@@ -249,11 +249,11 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
     });
   });
 
-  describe('merge offline mutations', function() {
+  describe('merge offline mutations', function () {
 
     let task;
 
-    beforeEach('prepare data', async function() {
+    beforeEach('prepare data', async function () {
       networkStatus.setOnline(true);
 
       const response = await client.mutate({
@@ -267,7 +267,7 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
       networkStatus.setOnline(false);
     });
 
-    it('should succeed', async function() {
+    it('should succeed', async function () {
       const variables = { title: 'update1', description: 'merge', id: task.id, version: task.version };
 
       client.mutate({
@@ -302,16 +302,20 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
     });
   });
 
-  describe.skip('noSquash mutations', function() {
-    it('should succeed', async function() {
+  describe('noSquash mutations', function () {
+    it('should succeed', async function () {
       const a = client.mutate({
         mutation: NO_SQUASH,
         variables: { id: 0 }
+      }).catch((error) => {
+        expect(error).to.exist;
       });
 
       const b = client.mutate({
         mutation: NO_SQUASH,
         variables: { id: 0 }
+      }).catch((error) => {
+        expect(error).to.exist;
       });
 
       const offlineMutationStore = JSON.parse(store.getItem(mutationsQueueName));
@@ -327,11 +331,11 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
     });
   });
 
-  describe('do not merge offline mutations', function() {
-  
+  describe('do not merge offline mutations', function () {
+
     let task;
 
-    beforeEach('prepare data', async function() {
+    beforeEach('prepare data', async function () {
       client = await newClient({ networkStatus, storage: store, mutationsQueueName, mergeOfflineMutations: false });
       networkStatus.setOnline(true);
 
@@ -346,7 +350,7 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
       networkStatus.setOnline(false);
     });
 
-    it('should succeed', async function() {
+    it('should succeed', async function () {
       const variables = { title: 'nomerge1', description: 'nomerge', id: task.id, version: task.version };
 
       client.mutate({
@@ -382,8 +386,8 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
     });
   });
 
-  describe('notify about offline changes', function() {
-    it('should succeed', async function() {
+  describe('notify about offline changes', function () {
+    it('should succeed', async function () {
       let offlineOps = 0;
       let cleared = 0;
 
@@ -409,25 +413,24 @@ describe('AeroGear Apollo GraphQL Voyager client', function() {
     });
   });
 
-  describe.skip('online only mutation', function() {
-    it('should succeed', async function() {
-      try {
-        await client.mutate({
-          mutation: ONLINE_ONLY,
-          variables: { id: 0 }
-        });
-      } catch (error) {
+  describe('online only mutation', function () {
+    it('should succeed', async function () {
+      networkStatus.setOnline(false);
+      await client.mutate({
+        mutation: ONLINE_ONLY,
+        variables: { id: 0 }
+      }).catch((error) => {
         expect(error).to.exist;
-        
-        networkStatus.setOnline(true);
+      });
 
-        await client.mutate({
-          mutation: ONLINE_ONLY,
-          variables: { id: 0 }
-        });
-      }
-      
-      throw new Error('Online mutation should fail when offline');
+      client.mutate({
+        mutation: ADD_TASK,
+        variables: newTask
+      });
+
+      let offlineMutationStore = JSON.parse(store.getItem(mutationsQueueName));
+      expect(offlineMutationStore.length).to.equal(1);
+      networkStatus.setOnline(true);
     });
   });
 

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -90,8 +90,11 @@ function createOfflineLink(config: DataSyncConfig) {
     listener: config.offlineQueueListener,
     networkStatus: config.networkStatus as NetworkStatus
   });
-  const localDirectiveFilterLink = new LocalDirectiveFilterLink();
-  let offlineLinks = ApolloLink.from([offlineLink, localDirectiveFilterLink]);
-  offlineLinks = ApolloLink.split((op: Operation) => isMutation(op) && !isOnlineOnly(op), offlineLinks);
+  const offlineLinks = ApolloLink.split((op: Operation) => {
+    return isMutation(op) && !isOnlineOnly(op);
+  },
+    offlineLink,
+    new LocalDirectiveFilterLink()
+  );
   return offlineLinks;
 }

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -90,11 +90,6 @@ function createOfflineLink(config: DataSyncConfig) {
     listener: config.offlineQueueListener,
     networkStatus: config.networkStatus as NetworkStatus
   });
-  const offlineLinks = ApolloLink.split((op: Operation) => {
-    return isMutation(op) && !isOnlineOnly(op);
-  },
-    offlineLink,
-    new LocalDirectiveFilterLink()
-  );
-  return offlineLinks;
+
+  return ApolloLink.from([offlineLink, new LocalDirectiveFilterLink()]);
 }

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -90,6 +90,7 @@ function createOfflineLink(config: DataSyncConfig) {
     listener: config.offlineQueueListener,
     networkStatus: config.networkStatus as NetworkStatus
   });
-
-  return ApolloLink.from([offlineLink, new LocalDirectiveFilterLink()]);
+  const localFilterLink = new LocalDirectiveFilterLink();
+  const mutationOfflineLink = ApolloLink.split((op: Operation) => isMutation(op) && !isOnlineOnly(op), offlineLink);
+  return ApolloLink.from([mutationOfflineLink, localFilterLink]);
 }

--- a/packages/sync/src/links/OfflineLink.ts
+++ b/packages/sync/src/links/OfflineLink.ts
@@ -2,7 +2,6 @@ import { ApolloLink, Operation, NextLink } from "apollo-link";
 import { PersistentStore, PersistedData } from "../PersistentStore";
 import { OfflineQueueListener, NetworkStatus, NetworkInfo } from "../offline";
 import { OfflineQueue } from "../offline/OfflineQueue";
-import { isOnlineOnly, isNotSquashable } from "../utils/helpers";
 
 export interface OfflineLinkOptions {
   networkStatus: NetworkStatus;
@@ -48,9 +47,6 @@ export class OfflineLink extends ApolloLink {
   }
 
   public request(operation: Operation, forward: NextLink) {
-    if (isOnlineOnly(operation)) {
-      return forward(operation);
-    }
     return this.queue.enqueue(operation, forward);
   }
 

--- a/packages/sync/src/links/OfflineLink.ts
+++ b/packages/sync/src/links/OfflineLink.ts
@@ -2,6 +2,7 @@ import { ApolloLink, Operation, NextLink } from "apollo-link";
 import { PersistentStore, PersistedData } from "../PersistentStore";
 import { OfflineQueueListener, NetworkStatus, NetworkInfo } from "../offline";
 import { OfflineQueue } from "../offline/OfflineQueue";
+import { isOnlineOnly, isNotSquashable } from "../utils/helpers";
 
 export interface OfflineLinkOptions {
   networkStatus: NetworkStatus;
@@ -47,6 +48,9 @@ export class OfflineLink extends ApolloLink {
   }
 
   public request(operation: Operation, forward: NextLink) {
+    if (isOnlineOnly(operation)) {
+      return forward(operation);
+    }
     return this.queue.enqueue(operation, forward);
   }
 

--- a/packages/sync/src/offline/OfflineQueue.ts
+++ b/packages/sync/src/offline/OfflineQueue.ts
@@ -4,6 +4,7 @@ import { OfflineQueueListener } from "./OfflineQueueListener";
 import { OperationQueue, OperationQueueChangeHandler } from "./OperationQueue";
 import { isClientGeneratedId } from "../cache/createOptimisticResponse";
 import { squashOperations } from "./squashOperations";
+import { isNotSquashable } from "../utils/helpers";
 
 export interface OfflineQueueOptions {
   storage?: PersistentStore<PersistedData>;
@@ -50,7 +51,7 @@ export class OfflineQueue extends OperationQueue {
   }
 
   protected enqueueEntry(entry: OperationQueueEntry) {
-    if (this.squashOperations) {
+    if (this.squashOperations && !isNotSquashable(entry.operation)) {
       this.queue = squashOperations(entry, this.queue);
     } else {
       this.queue.push(entry);

--- a/packages/sync/src/offline/OfflineQueue.ts
+++ b/packages/sync/src/offline/OfflineQueue.ts
@@ -4,7 +4,7 @@ import { OfflineQueueListener } from "./OfflineQueueListener";
 import { OperationQueue, OperationQueueChangeHandler } from "./OperationQueue";
 import { isClientGeneratedId } from "../cache/createOptimisticResponse";
 import { squashOperations } from "./squashOperations";
-import { isNotSquashable } from "../utils/helpers";
+import { isSquashable, isMutation } from "../utils/helpers";
 
 export interface OfflineQueueOptions {
   storage?: PersistentStore<PersistedData>;
@@ -51,7 +51,7 @@ export class OfflineQueue extends OperationQueue {
   }
 
   protected enqueueEntry(entry: OperationQueueEntry) {
-    if (this.squashOperations && !isNotSquashable(entry.operation)) {
+    if (this.squashOperations) {
       this.queue = squashOperations(entry, this.queue);
     } else {
       this.queue.push(entry);

--- a/packages/sync/src/offline/squashOperations.ts
+++ b/packages/sync/src/offline/squashOperations.ts
@@ -1,5 +1,6 @@
 import { OperationDefinitionNode, NameNode } from "graphql";
 import { hasDirectives } from "apollo-utilities";
+import { isSquashable } from "../utils/helpers";
 import { localDirectives } from "../config/Constants";
 import { OperationQueueEntry } from "./OperationQueueEntry";
 import { MUTATION_QUEUE_LOGGER } from "../config/Constants";
@@ -11,7 +12,7 @@ export const logger = debug(MUTATION_QUEUE_LOGGER);
  * Equality of operation is done by checking operationName and object id.
  */
 export function squashOperations(entry: OperationQueueEntry, opQueue: OperationQueueEntry[]): OperationQueueEntry[] {
-  if (hasDirectives([localDirectives.NO_SQUASH], entry.operation.query)) {
+  if (!isSquashable(entry.operation)) {
     opQueue.push(entry);
     return opQueue;
   }

--- a/packages/sync/src/utils/helpers.ts
+++ b/packages/sync/src/utils/helpers.ts
@@ -16,8 +16,8 @@ export const isOnlineOnly = (op: Operation) => {
   return hasDirectives([localDirectives.ONLINE_ONLY], op.query);
 };
 
-export const isNotSquashable = (op: Operation) => {
-  return hasDirectives([localDirectives.NO_SQUASH], op.query);
+export const isSquashable = (op: Operation) => {
+  return !hasDirectives([localDirectives.NO_SQUASH], op.query);
 };
 
 export const isNetworkError = (error: any) => {

--- a/packages/sync/src/utils/helpers.ts
+++ b/packages/sync/src/utils/helpers.ts
@@ -16,6 +16,10 @@ export const isOnlineOnly = (op: Operation) => {
   return hasDirectives([localDirectives.ONLINE_ONLY], op.query);
 };
 
+export const isNotSquashable = (op: Operation) => {
+  return hasDirectives([localDirectives.NO_SQUASH], op.query);
+};
+
 export const isNetworkError = (error: any) => {
   return !error.result;
 };


### PR DESCRIPTION
### Description
This small change fixes a bug whereby the local only directives were not being removed from the document before being sent to the server.

### Verification
Using this pr as the voyager-client in the showcase app, add @onlineOnly directive or @noSquash directive to the mutations and verify that everything works as expected.

@wtrocki we should probably add some feedback to the app as part of onlineOnly throwing an error in the client (at the moment its just in the console). however it will be hard to differentiate from a normal network error and an intentional one from onlineOnly. any thoughts?
