### PR TITLE
fix: fix broken conflict resolver check

### DIFF
--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -222,7 +222,7 @@ type Mutation {
 ### Conflict resolution strategies
 
 Client can define custom resolution strategies.
-You can provide custom conflict resolution strategies to the client in the config by using the provided `ConflictResolutionStrategy` type from the SDK. By default developers do not need to pass any strategy (`clientVersionWins` strategy is used).
+You can provide custom conflict resolution strategies to the client in the config by using the provided `ConflictResolutionStrategies` type from the SDK. By default developers do not need to pass any strategy (`clientVersionWins` strategy is used).
 Custom strategies can be used also to provide different resolution strategy for certain operations:
 
 

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -235,16 +235,20 @@ let updateUserConflictResolver = (serverData, clientData) => {
 let updateTaskConflictResolver = (serverData, clientData) => {
     ...
 };
+
+let defaultConflictResolver = (serverData, clientData) => {
+  ...
+};
 ```
 
 > Note: Client strategies will work only when specific server side resolver explicitly states that conflicts should be fixed on the client. Client strategy will be ignored when conflict is resolved on the server.
 
-To use strategy pass it as argument to conflictStrategy in your config object:
- 
+To use strategy pass it as argument to conflictStrategy in your config object, containing a default to use in the case where you do not provide a strategy for a specific mutations:
+
 ```javascript
 let config = {
 ...
-  conflictStrategy: {"TaskUpdated": updateTaskConflictResolver, "UserUpdated": updateUserConflictResolver}
+  conflictStrategy: {"TaskUpdated": updateTaskConflictResolver, "UserUpdated": updateUserConflictResolver, "default": defaultConflictResolver}
 ...
 }
 ```

--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -85,7 +85,7 @@ export interface DataSyncConfig {
   /**
    * The conflict resolution strategy your client should use. By default it takes client version.
    */
-  conflictStrategy?: ConflictResolutionStrategy | ConflictResolutionStrategies;
+  conflictStrategy?: ConflictResolutionStrategies;
 
   /**
    * Function that enables retry mechanism for queries that failed on network errors.

--- a/packages/sync/src/config/SyncConfig.ts
+++ b/packages/sync/src/config/SyncConfig.ts
@@ -6,6 +6,7 @@ import { WebNetworkStatus } from "../offline";
 import { CordovaNetworkStatus } from "../offline";
 import { diffMergeClientWins } from "../conflicts/strategies";
 import { VersionedNextState } from "../conflicts/VersionedNextState";
+import { ConflictResolutionData } from "../conflicts/ConflictResolutionData";
 
 declare var window: any;
 
@@ -36,6 +37,13 @@ export class SyncConfig implements DataSyncConfig {
    * Method used to join user configuration with defaults
    */
   public merge(clientOptions?: DataSyncConfig): DataSyncConfig {
+    if (clientOptions && clientOptions.conflictStrategy) {
+      if (!(clientOptions.conflictStrategy instanceof Function)
+            && clientOptions.conflictStrategy.default === undefined) {
+          clientOptions.conflictStrategy.default = (clientData: ConflictResolutionData,
+                                                    serverData: ConflictResolutionData) => clientData;
+      }
+    }
     return Object.assign(this, clientOptions);
   }
 

--- a/packages/sync/src/conflicts/ConflictResolutionStrategy.ts
+++ b/packages/sync/src/conflicts/ConflictResolutionStrategy.ts
@@ -19,8 +19,8 @@ export type ConflictResolutionStrategy =
  * @param client - client data
  */
 export interface ConflictResolutionStrategies {
-  strategies: {
+  default?: ConflictResolutionStrategy;
+  strategies?: {
     [operationName: string]: ConflictResolutionStrategy
   };
-  default: ConflictResolutionStrategy;
 }

--- a/packages/sync/src/conflicts/ConflictResolutionStrategy.ts
+++ b/packages/sync/src/conflicts/ConflictResolutionStrategy.ts
@@ -19,6 +19,6 @@ export type ConflictResolutionStrategy =
  * @param client - client data
  */
 export interface ConflictResolutionStrategies {
- [operationName: string]: (server: ConflictResolutionData,
-                           client: ConflictResolutionData) => ConflictResolutionData;
+ [operationName: string]: (server: ConflictResolutionData, client: ConflictResolutionData) => ConflictResolutionData;
+  default: (server: ConflictResolutionData, client: ConflictResolutionData) => ConflictResolutionData;
 }

--- a/packages/sync/src/conflicts/ConflictResolutionStrategy.ts
+++ b/packages/sync/src/conflicts/ConflictResolutionStrategy.ts
@@ -9,7 +9,7 @@ import { ConflictResolutionData } from "./ConflictResolutionData";
  * @param client - client data
  */
 export type ConflictResolutionStrategy =
-  (operationName: string, server: ConflictResolutionData, client: ConflictResolutionData) => ConflictResolutionData;
+  (server: ConflictResolutionData, client: ConflictResolutionData) => ConflictResolutionData;
 
 /**
  * Interface for conflict handlers that can be used to resolve conflicts.
@@ -19,6 +19,8 @@ export type ConflictResolutionStrategy =
  * @param client - client data
  */
 export interface ConflictResolutionStrategies {
- [operationName: string]: (server: ConflictResolutionData, client: ConflictResolutionData) => ConflictResolutionData;
-  default: (server: ConflictResolutionData, client: ConflictResolutionData) => ConflictResolutionData;
+  strategies: {
+    [operationName: string]: ConflictResolutionStrategy
+  };
+  default: ConflictResolutionStrategy;
 }

--- a/packages/sync/src/conflicts/conflictLink.ts
+++ b/packages/sync/src/conflicts/conflictLink.ts
@@ -43,11 +43,12 @@ export const conflictLink = (config: DataSyncConfig): ApolloLink => {
         // resolve on client
         if (config.conflictStrategy instanceof Function) {
           // ConflictResolutionStrategy interface is used
-          resolvedConflict = config.conflictStrategy(operation.operationName, data.serverState, data.clientState);
+          resolvedConflict = config.conflictStrategy(data.serverState, data.clientState);
         } else {
           // ConflictResolutionStrategies interface is used
-          if (config.conflictStrategy[operation.operationName] !== undefined) {
-            resolvedConflict = config.conflictStrategy[operation.operationName](data.serverState, data.clientState);
+          if (config.conflictStrategy.strategies[operation.operationName] !== undefined) {
+            // tslint:disable-next-line:max-line-length
+            resolvedConflict = config.conflictStrategy.strategies[operation.operationName](data.serverState, data.clientState);
           } else {
             resolvedConflict = config.conflictStrategy.default(data.serverState, data.clientState);
           }

--- a/packages/sync/src/conflicts/conflictLink.ts
+++ b/packages/sync/src/conflicts/conflictLink.ts
@@ -41,17 +41,13 @@ export const conflictLink = (config: DataSyncConfig): ApolloLink => {
         }
       } else {
         // resolve on client
-        if (config.conflictStrategy instanceof Function) {
-          // ConflictResolutionStrategy interface is used
-          resolvedConflict = config.conflictStrategy(data.serverState, data.clientState);
-        } else {
-          // ConflictResolutionStrategies interface is used
-          if (config.conflictStrategy.strategies[operation.operationName] !== undefined) {
-            // tslint:disable-next-line:max-line-length
-            resolvedConflict = config.conflictStrategy.strategies[operation.operationName](data.serverState, data.clientState);
-          } else {
-            resolvedConflict = config.conflictStrategy.default(data.serverState, data.clientState);
-          }
+        // ConflictResolutionStrategies interface is used
+        if (config.conflictStrategy.strategies &&
+          !!config.conflictStrategy.strategies[operation.operationName]) {
+          const individualStrategy = config.conflictStrategy.strategies[operation.operationName];
+          resolvedConflict = individualStrategy(data.serverState, data.clientState);
+        } else if (config.conflictStrategy.default) {
+          resolvedConflict = config.conflictStrategy.default(data.serverState, data.clientState);
         }
 
         if (config.conflictListener) {

--- a/packages/sync/src/conflicts/conflictLink.ts
+++ b/packages/sync/src/conflicts/conflictLink.ts
@@ -3,6 +3,7 @@ import { GraphQLError } from "graphql";
 import { DataSyncConfig } from "../config";
 import { ApolloLink } from "apollo-link";
 import { ConflictResolutionData } from "./ConflictResolutionData";
+import { diffMergeClientWins } from "./strategies";
 
 export const conflictLink = (config: DataSyncConfig): ApolloLink => {
   /**
@@ -45,7 +46,11 @@ export const conflictLink = (config: DataSyncConfig): ApolloLink => {
           resolvedConflict = config.conflictStrategy(operation.operationName, data.serverState, data.clientState);
         } else {
           // ConflictResolutionStrategies interface is used
-          resolvedConflict = config.conflictStrategy[operation.operationName](data.serverState, data.clientState);
+          if (config.conflictStrategy[operation.operationName] !== undefined) {
+            resolvedConflict = config.conflictStrategy[operation.operationName](data.serverState, data.clientState);
+          } else {
+            resolvedConflict = config.conflictStrategy.default(data.serverState, data.clientState);
+          }
         }
 
         if (config.conflictListener) {

--- a/packages/sync/src/conflicts/strategies.ts
+++ b/packages/sync/src/conflicts/strategies.ts
@@ -3,10 +3,10 @@ import { ConflictResolutionStrategy } from "./ConflictResolutionStrategy";
 
 // Used as default strategy for SDK
 export const diffMergeClientWins: ConflictResolutionStrategy =
-  (operationName: string, server: ConflictResolutionData, client: ConflictResolutionData) => {
+  (server: ConflictResolutionData, client: ConflictResolutionData) => {
     return client;
   };
 export const diffMergeServerWins: ConflictResolutionStrategy =
-  (operationName: string, server: ConflictResolutionData, client: ConflictResolutionData) => {
+  (server: ConflictResolutionData, client: ConflictResolutionData) => {
     return server;
   };

--- a/packages/sync/src/createClient.ts
+++ b/packages/sync/src/createClient.ts
@@ -41,10 +41,8 @@ export const createClient = async (userConfig?: DataSyncConfig): Promise<Voyager
  * Extract configuration from user and external sources
  */
 function extractConfig(userConfig: DataSyncConfig | undefined) {
-  const config = new SyncConfig();
-  const clientConfig = config.merge(userConfig);
-  config.applyPlatformConfig(clientConfig);
-  config.validate(clientConfig);
+  const config = new SyncConfig(userConfig);
+  const clientConfig = config.getClientConfig();
   return clientConfig;
 }
 


### PR DESCRIPTION
small fix to add a default to the conflictResolutionStrategy Interface. This means that if the user provides a resolution function for a specific mutation then they do not need to name all as the default can also be defined.