### PR TITLE
fix: Bump version of error link

### DIFF
--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -51,7 +51,7 @@
     "apollo-client": "2.4.5",
     "apollo-link": "1.2.3",
     "apollo-link-context": "^1.0.12",
-    "apollo-link-error": "^1.1.1",
+    "apollo-link-error": "^1.1.7",
     "apollo-link-http": "^1.5.5",
     "apollo-link-ws": "^1.0.9",
     "apollo-upload-client": "^10.0.0",


### PR DESCRIPTION
## Motivation 

Fix random crashes of the client when websockets are initiated too fast.
Errors that happening breaking entire client.

<img width="908" alt="screen shot 2019-02-22 at 8 27 45 pm" src="https://user-images.githubusercontent.com/981838/53270000-4a62ab80-36e2-11e9-968c-3e2c80a7bbde.png">

The solution is to use the latest version of the error package that has this fixed:
https://github.com/apollographql/apollo-link/blob/master/packages/apollo-link-error/src/index.ts#L67-L70