### PR TITLE
fix: use either variantId or variantID for push

### DIFF
--- a/packages/push/src/PushRegistration.ts
+++ b/packages/push/src/PushRegistration.ts
@@ -61,7 +61,15 @@ export class PushRegistration {
       return Promise.reject(new Error("UPS registration: Platform is configured." +
         "Please add UPS variant and generate mobile - config.json again"));
     }
-    const authToken = window.btoa(`${platformConfig.variantId}:${platformConfig.variantSecret}`);
+    const variantId = platformConfig.variantId || platformConfig.variantID;
+    const variantSecret = platformConfig.variantSecret;
+    if (!variantId) {
+      return Promise.reject(new Error("UPS registration: variantId is not defined."));
+    }
+    if (!variantSecret) {
+      return Promise.reject(new Error("UPS registration: variantSecret is not defined."));
+    }
+    const authToken = window.btoa(`${variantId}:${variantSecret}`);
     const postData = {
       "deviceToken": deviceToken,
       "deviceType": window.device.model,


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-8589

It seems like the ups-config is using `variantId` while UPS itself uses `variantID`. So the push sdk should be able to handle both. It should also check both `variantId` and `variantSecret` are valid, otherwise it should return an error.