### PR TITLE
fix: update to latest typescript

### DIFF
--- a/docs/templates/package.json
+++ b/docs/templates/package.json
@@ -40,7 +40,7 @@
     "@types/chai": "4.1.2",
     "@types/chai-as-promised": "7.1.0",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^9.4.6",
+    "@types/node": "11.9.5",
     "@types/proxyquire": "1.3.28",
     "@types/sinon": "^4.3.1",
     "browserify": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ts-node": "5.0.1",
     "tslint": "^5.13.0",
     "typedoc": "^0.14.2",
-    "typescript": "^2.7.2"
+    "typescript": "^3.3.3333"
   },
   "dependencies": {
     "@types/mocha": "^5.2.5"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -28,7 +28,8 @@
     "@types/chai": "^4.1.3",
     "chai": "^4.1.2",
     "mocha": "^5.1.1",
-    "nyc": "^11.7.1"
+    "nyc": "^11.7.1",
+    "typescript": "3.3.3333"
   },
   "dependencies": {
     "@aerogear/core": "2.1.1"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -53,7 +53,7 @@
     "@types/chai-as-promised": "7.1.0",
     "@types/loglevel": "^1.5.3",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^9.4.6",
+    "@types/node": "11.9.5",
     "@types/proxyquire": "1.3.28",
     "@types/sinon": "^4.3.1",
     "chai": "4.1.2",
@@ -64,7 +64,7 @@
     "sinon": "^4.5.0",
     "source-map-support": "^0.5.4",
     "ts-node": "5.0.1",
-    "typescript": "^2.8.1"
+    "typescript": "^3.3.3333"
   },
   "dependencies": {
     "@aerogear/core": "2.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "@types/lodash.find": "^4.6.3",
     "@types/loglevel": "^1.5.3",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^9.4.6",
+    "@types/node": "11.9.5",
     "@types/proxyquire": "1.3.28",
     "@types/sinon": "^4.3.1",
     "@types/uuid": "^3.4.3",
@@ -64,7 +64,7 @@
     "sinon": "^4.5.0",
     "source-map-support": "^0.5.4",
     "ts-node": "5.0.1",
-    "typescript": "^2.8.1"
+    "typescript": "^3.3.3333"
   },
   "dependencies": {
     "axios": "0.18.0",

--- a/packages/push/package.json
+++ b/packages/push/package.json
@@ -31,7 +31,8 @@
     "@types/chai": "^4.1.3",
     "chai": "^4.1.2",
     "mocha": "^5.1.1",
-    "nyc": "^11.7.1"
+    "nyc": "^11.7.1",
+    "typescript": "^3.3.3333"
   },
   "dependencies": {
     "@aerogear/core": "2.1.1",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -29,7 +29,8 @@
     "@types/chai": "^4.1.3",
     "chai": "^4.1.2",
     "mocha": "^5.1.1",
-    "nyc": "^11.7.1"
+    "nyc": "^11.7.1",
+    "typescript": "^3.3.3333"
   },
   "dependencies": {
     "@aerogear/core": "2.1.1"

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -42,7 +42,7 @@
     "mocha": "^5.1.1",
     "nyc": "^11.7.1",
     "ts-node": "^7.0.1",
-    "typescript": "^3.1.6"
+    "typescript": "^3.3.3333"
   },
   "dependencies": {
     "@aerogear/core": "2.1.1",

--- a/packages/sync/src/links/LocalDirectiveFilterLink.ts
+++ b/packages/sync/src/links/LocalDirectiveFilterLink.ts
@@ -10,7 +10,7 @@ import * as debug from "debug";
 export const logger = debug.default(MUTATION_QUEUE_LOGGER);
 
 export class LocalDirectiveFilterLink extends ApolloLink {
-  private readonly directiveRemovalConfig: any= [];
+  private readonly directiveRemovalConfig: any = [];
 
   constructor() {
     super();

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,10 @@
 {
   "extends": "tslint:recommended",
+  "linterOptions": {
+    "exclude": [
+      "node_modules/**"
+    ]
+  },
   "rules": {
     "jsdoc-format":false,
     "quotemark": [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/aerogear/aerogear-js-sdk/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

The reason we were experiencing compiler issues is that the versions of `@types/node` and `typescript` we were using were incompatible. Basically, there were some things that were being defined by both TypeScript and by the `types/node` lib.

In my opinion the simplest fix here is to bring both of those to the latest version.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
