### PR TITLE
AEROGEAR-8560 check compile success during release validity

### DIFF
--- a/scripts/validateRelease.sh
+++ b/scripts/validateRelease.sh
@@ -24,11 +24,25 @@ fi
 
 # validate that all packages have the same version found in lerna.json
 for package in $PACKAGES; do
-  version=$(lerna --loglevel=silent ls | grep $package | awk -F ' ' '{print $2}' | awk -F 'v' '{print $2}')
+  version=$(lerna --loglevel=silent ls -l | grep $package | awk -F ' ' '{print $2}' | awk -F 'v' '{print $2}')
   if [[ $version =~ $PACKAGE_VERSION ]]; then
     echo "package $package has version $version"
   else
     echo "package $package has version $version but expected $PACKAGE_VERSION"
+    exit 1
+  fi
+done
+
+for package in $PACKAGES; do
+  package_dir=$(lerna --loglevel=silent ls -l | grep $package | awk -F ' ' '{print $3}')
+  package_dist_dir="${package_dir}/dist"
+  package_plugin_xml="${package_dir}/plugin.xml"
+  if [ -d "${package_dist_dir}" ]; then
+    echo "dist dir ${package_dist_dir} present"
+  elif [ -f "${package_plugin_xml}" ]; then
+    echo "dist dir ${package_dist_dir} not present but package is a Cordova plugin"
+  else
+    echo "dist dir ${package_dist_dir} not present and the package is not a Cordova plugin, possible compilation error"
     exit 1
   fi
 done


### PR DESCRIPTION
Similar with https://github.com/aerogear/voyager-server/pull/126

@wtrocki In Voyager server if there's a compilation error, dist folder is empty. But not in JS sdk.
I couldn't figure out why.

Anyway, this is not the perfect check, but it would be thought as a smoke check only.