### PR TITLE
fix: Remove fixed version from optimistic response

### DIFF
--- a/packages/sync/src/cache/createOptimisticResponse.ts
+++ b/packages/sync/src/cache/createOptimisticResponse.ts
@@ -50,7 +50,7 @@ export const createOptimisticResponse =
     optimisticResponse[operation] = {
       __typename: typeName,
       ...data,
-      version: 1,
+
       optimisticResponse: true
     };
     if (addId) {


### PR DESCRIPTION
# Motivation

Fix critical issue for optimistic responses where version is always fixed to 1. 
This is going to cause conflicts when edit is made twice