### PR TITLE
fix: implement sequential ordering of offline queue items

### DIFF
--- a/packages/sync/integration_test/test/offline.test.js
+++ b/packages/sync/integration_test/test/offline.test.js
@@ -1,5 +1,4 @@
 import { createClient, createOptimisticResponse } from '../../dist';
-
 import { TestStore } from '../utils/testStore';
 import { ToggleableNetworkStatus } from '../utils/network';
 import server from '../utils/server';
@@ -250,7 +249,7 @@ describe('AeroGear Apollo GraphQL Voyager client', function () {
     });
   });
 
-  describe('merge offline mutations', function () {
+  describe('queue offline mutations', function () {
 
     let task;
 
@@ -276,6 +275,8 @@ describe('AeroGear Apollo GraphQL Voyager client', function () {
         variables
       });
 
+      const firstUpdateTitle = variables.title;
+
       variables.title = 'update2';
 
       client.mutate({
@@ -285,8 +286,9 @@ describe('AeroGear Apollo GraphQL Voyager client', function () {
 
       const offlineMutationStore = JSON.parse(store.getItem(mutationsQueueName));
 
-      expect(offlineMutationStore.length).to.equal(1);
-      expect(offlineMutationStore[0].operation.variables.title).to.equal(variables.title);
+      expect(offlineMutationStore.length).to.equal(2);
+      expect(offlineMutationStore[0].operation.variables.title).to.equal(firstUpdateTitle);
+      expect(offlineMutationStore[1].operation.variables.title).to.equal(variables.title);
 
       networkStatus.setOnline(true);
 
@@ -337,7 +339,7 @@ describe('AeroGear Apollo GraphQL Voyager client', function () {
     let task;
 
     beforeEach('prepare data', async function () {
-      client = await newClient({ networkStatus, storage: store, mutationsQueueName, mergeOfflineMutations: false });
+      client = await newClient({ networkStatus, storage: store, mutationsQueueName});
       networkStatus.setOnline(true);
 
       const response = await client.mutate({

--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -3,7 +3,7 @@ import { PersistedData, PersistentStore } from "../PersistentStore";
 import { NetworkStatus } from "../offline";
 import { OfflineQueueListener } from "../offline";
 import { AuthContextProvider } from "./AuthContextProvider";
-import { NextState } from "../conflicts/NextState";
+import { ObjectState } from "../conflicts/ObjectState";
 import { ConflictListener } from "../conflicts/ConflictListener";
 import { ConfigurationService } from "@aerogear/core";
 import { shouldRetryFn } from "../offline/RetriableOperation";
@@ -41,7 +41,7 @@ export interface DataSyncConfig {
   mutationsQueueName?: string | any;
 
   /**
-   * Whether or not you wish to squash mutations in your queue. By default true
+   * Whether or not you wish to squash mutations in your queue. By default false
    */
   mergeOfflineMutations?: boolean;
 
@@ -70,7 +70,7 @@ export interface DataSyncConfig {
   /**
    * Interface that defines how object state is progressed
    */
-  conflictStateProvider?: NextState;
+  conflictStateProvider?: ObjectState;
 
   /**
    * Interface that can be implemented to receive information about the data conflict
@@ -92,4 +92,5 @@ export interface DataSyncConfig {
    * See https://www.apollographql.com/docs/link/links/retry.html for more information
    */
   shouldRetry?: shouldRetryFn;
+
 }

--- a/packages/sync/src/config/SyncConfig.ts
+++ b/packages/sync/src/config/SyncConfig.ts
@@ -5,7 +5,7 @@ import { DataSyncConfig } from "./DataSyncConfig";
 import { WebNetworkStatus } from "../offline";
 import { CordovaNetworkStatus } from "../offline";
 import { diffMergeClientWins } from "../conflicts/strategies";
-import { VersionedNextState } from "../conflicts/VersionedNextState";
+import { VersionedState } from "../conflicts/VersionedState";
 import { ConflictResolutionStrategies } from "../conflicts";
 
 declare var window: any;
@@ -42,10 +42,10 @@ export class SyncConfig implements DataSyncConfig {
 
   public storage?: PersistentStore<PersistedData>;
   public mutationsQueueName = "offline-mutation-store";
-  public mergeOfflineMutations = true;
+  public mergeOfflineMutations = false;
   public auditLogging = false;
   public conflictStrategy: ConflictResolutionStrategies;
-  public conflictStateProvider = new VersionedNextState();
+  public conflictStateProvider = new VersionedState();
 
   public networkStatus = (isMobileCordova()) ? new CordovaNetworkStatus() : new WebNetworkStatus();
   private clientConfig: DataSyncConfig;

--- a/packages/sync/src/conflicts/ObjectState.ts
+++ b/packages/sync/src/conflicts/ObjectState.ts
@@ -1,12 +1,17 @@
 import { ConflictResolutionData } from "./ConflictResolutionData";
 
 /**
- * Interface for handling changing state of the object.
+ * Interface for handling state of the object.
  */
-export interface NextState {
+export interface ObjectState {
   /**
    * @param currentObjectState the object wish you would like
    * to progress to its next state
    */
   nextState(currentObjectState: ConflictResolutionData): ConflictResolutionData;
+
+   /**
+   * @param currentObjectState the object wish you would like to get the current state from
+   */
+  currentState(currentObjectState: ConflictResolutionData): ConflictResolutionData;
 }

--- a/packages/sync/src/conflicts/VersionedState.ts
+++ b/packages/sync/src/conflicts/VersionedState.ts
@@ -1,5 +1,5 @@
 import { ConflictResolutionData } from "./ConflictResolutionData";
-import { NextState } from "./NextState";
+import { ObjectState } from "./ObjectState";
 
 /**
  * Object state manager using a version field
@@ -13,10 +13,14 @@ import { NextState } from "./NextState";
  *   version: String
  * }
  */
-export class VersionedNextState implements NextState {
+export class VersionedState implements ObjectState {
 
   public nextState(currentObjectState: ConflictResolutionData) {
     currentObjectState.version = currentObjectState.version + 1;
     return currentObjectState;
+  }
+
+  public currentState(currentObjectState: ConflictResolutionData) {
+    return currentObjectState.version;
   }
 }

--- a/packages/sync/src/conflicts/index.ts
+++ b/packages/sync/src/conflicts/index.ts
@@ -1,5 +1,5 @@
 export * from "./strategies";
 export * from "./conflictLink";
 export * from "./ConflictListener";
-export * from "./NextState";
+export * from "./ObjectState";
 export * from "./ConflictResolutionStrategy";

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -88,7 +88,8 @@ function createOfflineLink(config: DataSyncConfig) {
     storageKey: config.mutationsQueueName,
     squashOperations: config.mergeOfflineMutations,
     listener: config.offlineQueueListener,
-    networkStatus: config.networkStatus as NetworkStatus
+    networkStatus: config.networkStatus as NetworkStatus,
+    conflictStateProvider: config.conflictStateProvider
   });
   const localFilterLink = new LocalDirectiveFilterLink();
   const mutationOfflineLink = ApolloLink.split((op: Operation) => isMutation(op) && !isOnlineOnly(op), offlineLink);

--- a/packages/sync/src/links/OfflineLink.ts
+++ b/packages/sync/src/links/OfflineLink.ts
@@ -2,6 +2,7 @@ import { ApolloLink, Operation, NextLink } from "apollo-link";
 import { PersistentStore, PersistedData } from "../PersistentStore";
 import { OfflineQueueListener, NetworkStatus, NetworkInfo } from "../offline";
 import { OfflineQueue } from "../offline/OfflineQueue";
+import { ObjectState } from "../conflicts";
 
 export interface OfflineLinkOptions {
   networkStatus: NetworkStatus;
@@ -9,6 +10,7 @@ export interface OfflineLinkOptions {
   storageKey?: string;
   squashOperations?: boolean;
   listener?: OfflineQueueListener;
+  conflictStateProvider?: ObjectState;
 }
 
 /**
@@ -56,10 +58,10 @@ export class OfflineLink extends ApolloLink {
     }
   }
 
-  private forward() {
-    this.queue.toBeForwarded().forEach(operation =>
-      operation.forwardOperation()
-    );
+  private async forward() {
+    for (const operation of this.queue.toBeForwarded()) {
+      await operation.forwardOperation();
+    }
   }
 
   private async forwardOnOnline() {


### PR DESCRIPTION
this is a small change to implement sequential ordering of the offline queue. this is needed to stop client data conflicting with itself.