### PR TITLE
chore: release 2.2.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.2.0-rc1",
+  "version": "2.2.0",
   "command": {
     "publish": {
       "exact": true

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/app",
-  "version": "2.2.0-rc1",
+  "version": "2.2.0",
   "description": "Aero Gear SDK application module",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -32,6 +32,6 @@
     "typescript": "3.3.3333"
   },
   "dependencies": {
-    "@aerogear/core": "2.2.0-rc1"
+    "@aerogear/core": "2.2.0"
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/auth",
-  "version": "2.2.0-rc1",
+  "version": "2.2.0",
   "description": "JavaScript Auth module for AeroGear services",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -67,7 +67,7 @@
     "typescript": "3.3.3333"
   },
   "dependencies": {
-    "@aerogear/core": "2.2.0-rc1",
+    "@aerogear/core": "2.2.0",
     "keycloak-js": "4.8.3",
     "loglevel": "1.6.1",
     "url": "0.11.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/core",
-  "version": "2.2.0-rc1",
+  "version": "2.2.0",
   "description": "JavaScript Core SDK for AeroGear services",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/packages/metrics-cordova/package.json
+++ b/packages/metrics-cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/cordova-plugin-aerogear-metrics",
-  "version": "2.2.0-rc1",
+  "version": "2.2.0",
   "description": "Cordova plugin for AeroGear Metrics",
   "cordova": {
     "id": "cordova-plugin-aerogear-metrics",

--- a/packages/metrics-cordova/plugin.xml
+++ b/packages/metrics-cordova/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin
     id="cordova-plugin-aerogear-metrics"
-    version="2.2.0-rc1"
+    version="2.2.0"
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/packages/push-cordova/package.json
+++ b/packages/push-cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/cordova-plugin-aerogear-push",
-  "version": "2.2.0-rc1",
+  "version": "2.2.0",
   "description": "Cordova plugin for AeroGear Push Notifications",
   "cordova": {
     "id": "cordova-plugin-aerogear-push",

--- a/packages/push-cordova/plugin.xml
+++ b/packages/push-cordova/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin
     id="cordova-plugin-aerogear-push"
-    version="2.2.0-rc1"
+    version="2.2.0"
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/packages/push/package.json
+++ b/packages/push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/push",
-  "version": "2.2.0-rc1",
+  "version": "2.2.0",
   "description": "AeroGear Unified Push Registration SDK",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -35,7 +35,7 @@
     "typescript": "3.3.3333"
   },
   "dependencies": {
-    "@aerogear/core": "2.2.0-rc1",
+    "@aerogear/core": "2.2.0",
     "axios": "0.18.0"
   }
 }

--- a/packages/security-cordova/package.json
+++ b/packages/security-cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/cordova-plugin-aerogear-security",
-  "version": "2.2.0-rc1",
+  "version": "2.2.0",
   "description": "Cordova plugin for self defence checks for Android and iOS devices.",
   "cordova": {
     "id": "cordova-plugin-aerogear-security",

--- a/packages/security-cordova/plugin.xml
+++ b/packages/security-cordova/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin
     id="cordova-plugin-aerogear-security"
-    version="2.2.0-rc1"
+    version="2.2.0"
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/security",
-  "version": "2.2.0-rc1",
+  "version": "2.2.0",
   "description": "AeroGear Services JavaScript Security SDK",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -33,6 +33,6 @@
     "typescript": "3.3.3333"
   },
   "dependencies": {
-    "@aerogear/core": "2.2.0-rc1"
+    "@aerogear/core": "2.2.0"
   }
 }

--- a/packages/sync-cordova/package.json
+++ b/packages/sync-cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/cordova-plugin-aerogear-sync",
-  "version": "2.2.0-rc1",
+  "version": "2.2.0",
   "description": "Cordova plugin for AeroGear Sync",
   "cordova": {
     "id": "cordova-plugin-aerogear-sync",

--- a/packages/sync-cordova/plugin.xml
+++ b/packages/sync-cordova/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin
     id="cordova-plugin-aerogear-sync"
-    version="2.2.0-rc1"
+    version="2.2.0"
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/voyager-client",
-  "version": "2.2.0-rc1",
+  "version": "2.2.0",
   "description": "AeroGear Voyager GraphQL client",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -45,7 +45,7 @@
     "typescript": "3.3.3333"
   },
   "dependencies": {
-    "@aerogear/core": "2.2.0-rc1",
+    "@aerogear/core": "2.2.0",
     "apollo-cache-inmemory": "1.5.1",
     "apollo-cache-persist": "0.1.1",
     "apollo-client": "2.5.1",


### PR DESCRIPTION
## Release 2.2.0

### Release notes

- FIX: Updated to latest versions of Apollo Client and related libraries
- BREAKING: New way to configure conflict resolution using an object format:
`conflictStrategy: clientWins` => `conflictStrategy:{ default:clien

