### PR TITLE
Process queue only when offline

### DIFF
--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -110,5 +110,4 @@ export interface DataSyncConfig {
    * By default offline requests are retried 5 times.
    */
   shouldRetry?: ShouldRetryFn;
-
 }

--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -105,7 +105,7 @@ export interface DataSyncConfig {
   /**
    * [Modifier]
    *
-   * Function that enables retry mechanism for queries that failed on network errors.
+   * Function that overrides retry mechanism for offline mutations that failed on network errors.
    * See https://www.apollographql.com/docs/link/links/retry.html for more information
    */
   shouldRetry?: shouldRetryFn;

--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -6,7 +6,7 @@ import { AuthContextProvider } from "../auth/AuthContextProvider";
 import { ObjectState } from "../conflicts/ObjectState";
 import { ConflictListener } from "../conflicts/ConflictListener";
 import { ConfigurationService } from "@aerogear/core";
-import { shouldRetryFn } from "../offline/RetriableOperation";
+import { ShouldRetryFn } from "../offline/retry/ShouldRetry";
 
 /**
  * Contains all configuration options required to initialize Voyager Client
@@ -105,9 +105,10 @@ export interface DataSyncConfig {
   /**
    * [Modifier]
    *
-   * Function that overrides retry mechanism for offline mutations that failed on network errors.
+   * Function that customizes retry mechanism for queries that failed on network errors.
    * See https://www.apollographql.com/docs/link/links/retry.html for more information
+   * By default offline requests are retried 5 times.
    */
-  shouldRetry?: shouldRetryFn;
+  shouldRetry?: ShouldRetryFn;
 
 }

--- a/packages/sync/src/config/SyncConfig.ts
+++ b/packages/sync/src/config/SyncConfig.ts
@@ -2,11 +2,12 @@ import { ServiceConfiguration, isMobileCordova } from "@aerogear/core";
 import { PersistedData, PersistentStore } from "../PersistentStore";
 import { ConfigError } from "./ConfigError";
 import { DataSyncConfig } from "./DataSyncConfig";
-import { WebNetworkStatus } from "../offline";
+import { WebNetworkStatus, NetworkStatus } from "../offline";
 import { CordovaNetworkStatus } from "../offline";
 import { clientWins } from "../conflicts/strategies";
 import { VersionedState } from "../conflicts/VersionedState";
 import { ConflictResolutionStrategies } from "../conflicts";
+import { defaultRetryFn } from "../offline/retry/ShouldRetry";
 
 declare var window: any;
 
@@ -45,14 +46,18 @@ export class SyncConfig implements DataSyncConfig {
   public auditLogging = false;
   public conflictStrategy: ConflictResolutionStrategies;
   public conflictStateProvider = new VersionedState();
+  public shouldRetry = defaultRetryFn;
 
-  public networkStatus = (isMobileCordova()) ? new CordovaNetworkStatus() : new WebNetworkStatus();
+  public networkStatus: NetworkStatus;
   private clientConfig: DataSyncConfig;
 
   constructor(clientOptions?: DataSyncConfig) {
     if (window) {
       this.storage = window.localStorage;
     }
+    this.networkStatus = (isMobileCordova()) ?
+      new CordovaNetworkStatus() : new WebNetworkStatus();
+
     if (clientOptions && clientOptions.conflictStrategy) {
       this.conflictStrategy = clientOptions.conflictStrategy;
       if (!clientOptions.conflictStrategy.default) {

--- a/packages/sync/src/links/AuthLink.ts
+++ b/packages/sync/src/links/AuthLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink, NextLink, Operation } from "apollo-link";
+import { ApolloLink } from "apollo-link";
 import { setContext } from "apollo-link-context";
 import { DataSyncConfig } from "../config/DataSyncConfig";
 

--- a/packages/sync/src/links/ExtensionsLink.ts
+++ b/packages/sync/src/links/ExtensionsLink.ts
@@ -1,0 +1,16 @@
+import { ApolloLink } from "apollo-link";
+
+/**
+ * Purpose of this link is to restore persisted GraphQL extensions that were passed back to client as context.
+ * See OfflineRestoreHandler that is passing extensions into context.
+ */
+export const extensionsLink = new ApolloLink((operation, forward) => {
+  const extensions = operation.getContext().extensions;
+  operation.extensions = extensions;
+
+  if (forward) {
+    return forward(operation);
+  } else {
+    return null;
+  }
+});

--- a/packages/sync/src/links/ExtensionsLink.ts
+++ b/packages/sync/src/links/ExtensionsLink.ts
@@ -6,8 +6,9 @@ import { ApolloLink } from "apollo-link";
  */
 export const extensionsLink = new ApolloLink((operation, forward) => {
   const extensions = operation.getContext().extensions;
-  operation.extensions = extensions;
-
+  if (extensions) {
+    operation.extensions = extensions;
+  }
   if (forward) {
     return forward(operation);
   } else {

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -42,11 +42,6 @@ export const defaultHttpLinks = async (config: DataSyncConfig): Promise<ApolloLi
     links.push(await createAuditLoggingLink(config));
   }
 
-  if (config.shouldRetry) {
-    const retryLink = new RetryLink(config);
-    links.push(retryLink);
-  }
-
   if (config.conflictStrategy) {
     links.push(conflictLink(config));
   }
@@ -95,9 +90,11 @@ function createOfflineLink(config: DataSyncConfig) {
     return isMutation(op) && !isOnlineOnly(op);
   }, offlineLink);
 
+  const retryLink = new RetryLink(config);
+
   const retryOfflineMutationsLink = ApolloLink.split((op: Operation) => {
     return markedOffline(op);
-  }, offlineLink);
+  }, retryLink);
 
   return ApolloLink.from([mutationOfflineLink, retryOfflineMutationsLink, localFilterLink]);
 }

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -12,6 +12,7 @@ import { defaultWebSocketLink } from "./WebsocketLink";
 import { OfflineLink } from "./OfflineLink";
 import { RetryLink } from "./RetryLink";
 import { NetworkStatus } from "../offline";
+import { extensionsLink } from "./ExtensionsLink";
 
 /**
  * Default Apollo Link
@@ -36,7 +37,7 @@ export const defaultLink = async (config: DataSyncConfig) => {
  * - Audit logging
  */
 export const defaultHttpLinks = async (config: DataSyncConfig): Promise<ApolloLink> => {
-  const links: ApolloLink[] = [createOfflineLink(config)];
+  const links: ApolloLink[] = [extensionsLink, createOfflineLink(config)];
 
   if (config.auditLogging) {
     links.push(await createAuditLoggingLink(config));

--- a/packages/sync/src/links/OfflineLink.ts
+++ b/packages/sync/src/links/OfflineLink.ts
@@ -49,7 +49,13 @@ export class OfflineLink extends ApolloLink {
   }
 
   public request(operation: Operation, forward: NextLink) {
-    if (this.online && !markedOffline(operation)) {
+    const enqueuedWhenOffline = markedOffline(operation);
+    if (enqueuedWhenOffline) {
+      // Operation was processed before and needs to be enqueued again
+      return this.queue.enqueue(operation, forward);
+    }
+    if (this.online) {
+      // We are online and can skip this link;
       return forward(operation);
     }
     markOffline(operation);

--- a/packages/sync/src/links/OfflineLink.ts
+++ b/packages/sync/src/links/OfflineLink.ts
@@ -3,6 +3,7 @@ import { PersistentStore, PersistedData } from "../PersistentStore";
 import { OfflineQueueListener, NetworkStatus, NetworkInfo } from "../offline";
 import { OfflineQueue } from "../offline/OfflineQueue";
 import { ObjectState } from "../conflicts";
+import { markedOffline, markOffline } from "../utils/helpers";
 
 export interface OfflineLinkOptions {
   networkStatus: NetworkStatus;
@@ -48,6 +49,10 @@ export class OfflineLink extends ApolloLink {
   }
 
   public request(operation: Operation, forward: NextLink) {
+    if (this.online && !markedOffline(operation)) {
+      return forward(operation);
+    }
+    markOffline(operation);
     return this.queue.enqueue(operation, forward);
   }
 

--- a/packages/sync/src/links/RetryLink.ts
+++ b/packages/sync/src/links/RetryLink.ts
@@ -49,26 +49,9 @@ export class RetryLink extends ApolloLink {
     if (isMutation(operation)) {
       return this.queue.enqueue(operation, forward, RetriableOperation);
     } else {
-      const observer = forward(operation);
-      this.forceRetryOnCompletedQuery(observer);
-      return observer;
+      // Enable only for mutations
+      return forward(operation);
     }
-  }
-
-  /**
-   * This makes sure that pending mutations are force retried also
-   * when there is query with response from server.
-   */
-  private forceRetryOnCompletedQuery(observer: Observable<FetchResult>) {
-    const self = this;
-    observer.subscribe({
-      complete: self.forceRetry,
-      error: error => {
-        if (!isNetworkError(error)) {
-          self.forceRetry();
-        }
-      }
-    });
   }
 
   private try() {

--- a/packages/sync/src/links/RetryLink.ts
+++ b/packages/sync/src/links/RetryLink.ts
@@ -1,10 +1,11 @@
 import { ApolloLink, Operation, NextLink, Observable, FetchResult } from "apollo-link";
 import { OperationQueue } from "../offline/OperationQueue";
 import { isMutation, isNetworkError } from "../utils/helpers";
-import { RetriableOperation, shouldRetryFn } from "../offline/RetriableOperation";
+import { RetriableOperation } from "../offline/retry/RetriableOperation";
+import { ShouldRetryFn } from "../offline/retry/ShouldRetry";
 
 export interface RetryLinkOptions {
-  shouldRetry?: shouldRetryFn;
+  shouldRetry?: ShouldRetryFn;
 }
 
 /**
@@ -24,7 +25,7 @@ export interface RetryLinkOptions {
  */
 export class RetryLink extends ApolloLink {
   private queue: OperationQueue;
-  private shouldRetry: shouldRetryFn;
+  private shouldRetry: ShouldRetryFn;
 
   constructor(options: RetryLinkOptions) {
     super();

--- a/packages/sync/src/offline/OfflineQueue.ts
+++ b/packages/sync/src/offline/OfflineQueue.ts
@@ -64,7 +64,6 @@ export class OfflineQueue extends OperationQueue {
       this.updateIds(entry);
       this.updateVersions(entry);
 
-
       this.persist();
 
       if (this.queue.length === 0 && this.listener && this.listener.queueCleared) {

--- a/packages/sync/src/offline/OfflineQueueListener.ts
+++ b/packages/sync/src/offline/OfflineQueueListener.ts
@@ -20,8 +20,11 @@ export interface OfflineQueueListener {
 
   /**
    * Called when back online and operation fails with GraphQL error
+   *
+   * error - application error (it means that user need to react to error and sent this operation again)
+   * networkError - operation was retried but it did not reached server (it will be reatempted again)
    */
-  onOperationFailure?: (operation: Operation, error: any) => void;
+  onOperationFailure?: (operation: Operation, graphQLError?: any, networkError?: any) => void;
 
   /**
    * Called when offline operation queue is cleared

--- a/packages/sync/src/offline/OfflineRestoreHandler.ts
+++ b/packages/sync/src/offline/OfflineRestoreHandler.ts
@@ -19,8 +19,8 @@ export class OfflineRestoreHandler {
   private offlineData: OperationQueueEntry[] = [];
 
   constructor(apolloClient: ApolloClient<NormalizedCacheObject>,
-              storage: PersistentStore<PersistedData>,
-              storageKey: string) {
+    storage: PersistentStore<PersistedData>,
+    storageKey: string) {
     this.apolloClient = apolloClient;
     this.storage = storage;
     this.storageKey = storageKey;
@@ -45,12 +45,16 @@ export class OfflineRestoreHandler {
     await this.clearOfflineData();
 
     logger("Replying offline mutations after application restart");
-
     this.offlineData.forEach(item => {
+      const extensions = item.operation.extensions;
+      const optimisticResponse = item.optimisticResponse;
       this.apolloClient.mutate({
         variables: item.operation.variables,
         mutation: item.operation.query,
-        optimisticResponse: item.optimisticResponse
+        // Restore optimistic response from operation in order to see it
+        optimisticResponse,
+        // Pass extensions as part of the context
+        context: { extensions }
       });
     });
 

--- a/packages/sync/src/offline/OfflineRestoreHandler.ts
+++ b/packages/sync/src/offline/OfflineRestoreHandler.ts
@@ -19,8 +19,8 @@ export class OfflineRestoreHandler {
   private offlineData: OperationQueueEntry[] = [];
 
   constructor(apolloClient: ApolloClient<NormalizedCacheObject>,
-    storage: PersistentStore<PersistedData>,
-    storageKey: string) {
+              storage: PersistentStore<PersistedData>,
+              storageKey: string) {
     this.apolloClient = apolloClient;
     this.storage = storage;
     this.storageKey = storageKey;

--- a/packages/sync/src/offline/OperationQueueEntry.ts
+++ b/packages/sync/src/offline/OperationQueueEntry.ts
@@ -19,8 +19,10 @@ export class OperationQueueEntry {
   public readonly optimisticResponse?: any;
   public subscription?: { unsubscribe: () => void };
   public result?: FetchResult;
+  public error: any;
   protected resolveForward?: (value?: {} | PromiseLike<{}> | undefined) => void;
   protected rejectForward?: (reason?: any) => void;
+
 
   constructor(options: OperationQueueEntryOptions) {
     const { operation, forward } = options;
@@ -64,6 +66,7 @@ export class OperationQueueEntry {
   }
 
   protected handleError(error: any) {
+    this.error = error;
     if (this.observer && this.observer.error) {
       this.observer.error(error);
     }

--- a/packages/sync/src/offline/OperationQueueEntry.ts
+++ b/packages/sync/src/offline/OperationQueueEntry.ts
@@ -19,10 +19,9 @@ export class OperationQueueEntry {
   public readonly optimisticResponse?: any;
   public subscription?: { unsubscribe: () => void };
   public result?: FetchResult;
-  public error: any;
+  public networkError: any;
   protected resolveForward?: (value?: {} | PromiseLike<{}> | undefined) => void;
   protected rejectForward?: (reason?: any) => void;
-
 
   constructor(options: OperationQueueEntryOptions) {
     const { operation, forward } = options;
@@ -66,7 +65,7 @@ export class OperationQueueEntry {
   }
 
   protected handleError(error: any) {
-    this.error = error;
+    this.networkError = error;
     if (this.observer && this.observer.error) {
       this.observer.error(error);
     }

--- a/packages/sync/src/offline/retry/RetriableOperation.ts
+++ b/packages/sync/src/offline/retry/RetriableOperation.ts
@@ -47,7 +47,7 @@ export class RetriableOperation extends OperationQueueEntry {
             setTimeout(resolve, this.timeout);
           });
 
-          this.timeout *= 2;
+          this.timeout *= 3;
           attempts++;
 
           retry = shouldRetry(attempts, this.operation, error);

--- a/packages/sync/src/offline/retry/RetriableOperation.ts
+++ b/packages/sync/src/offline/retry/RetriableOperation.ts
@@ -1,11 +1,9 @@
-import { isNetworkError } from "../utils/helpers";
-import { OperationQueueEntry } from "./OperationQueueEntry";
-import { Operation } from "apollo-link";
+import { isNetworkError } from "../../utils/helpers";
+import { OperationQueueEntry } from "../OperationQueueEntry";
+import { ShouldRetryFn } from "./ShouldRetry";
 
 // Initial timeout for first retry
 const INITIAL_TIMEOUT = 1000;
-
-export type shouldRetryFn = (count: number, operation: Operation, error: any) => boolean;
 
 /**
  * Class implementing retry mechanism for operation.
@@ -33,7 +31,7 @@ export class RetriableOperation extends OperationQueueEntry {
    * shouldRetry function is called with every network fail
    * to determine if the operation should be retried.
    */
-  public async try(shouldRetry: shouldRetryFn) {
+  public async try(shouldRetry: ShouldRetryFn) {
     let networkError;
     let retry;
     let attempts = 0;

--- a/packages/sync/src/offline/retry/RetriableOperation.ts
+++ b/packages/sync/src/offline/retry/RetriableOperation.ts
@@ -5,6 +5,9 @@ import { ShouldRetryFn } from "./ShouldRetry";
 // Initial timeout for first retry
 const INITIAL_TIMEOUT = 1000;
 
+// Every retry INITIAL_TIMEOUT is multiplied by TIMEOUT_MULTIPLIER
+const TIMEOUT_MULTIPLIER = 3;
+
 /**
  * Class implementing retry mechanism for operation.
  *
@@ -47,7 +50,7 @@ export class RetriableOperation extends OperationQueueEntry {
             setTimeout(resolve, this.timeout);
           });
 
-          this.timeout *= 3;
+          this.timeout *= TIMEOUT_MULTIPLIER;
           attempts++;
 
           retry = shouldRetry(attempts, this.operation, error);

--- a/packages/sync/src/offline/retry/ShouldRetry.ts
+++ b/packages/sync/src/offline/retry/ShouldRetry.ts
@@ -2,4 +2,4 @@ import { Operation } from "apollo-link";
 
 export type ShouldRetryFn = (count: number, operation: Operation, error: any) => boolean;
 
-export const defaultRetryFn: ShouldRetryFn = (count) => count < 5;
+export const defaultRetryFn: ShouldRetryFn = (count) => count < 3;

--- a/packages/sync/src/offline/retry/ShouldRetry.ts
+++ b/packages/sync/src/offline/retry/ShouldRetry.ts
@@ -1,0 +1,5 @@
+import { Operation } from "apollo-link";
+
+export type ShouldRetryFn = (count: number, operation: Operation, error: any) => boolean;
+
+export const defaultRetryFn: ShouldRetryFn = (count) => count < 5;

--- a/packages/sync/src/offline/retry/ShouldRetry.ts
+++ b/packages/sync/src/offline/retry/ShouldRetry.ts
@@ -2,4 +2,4 @@ import { Operation } from "apollo-link";
 
 export type ShouldRetryFn = (count: number, operation: Operation, error: any) => boolean;
 
-export const defaultRetryFn: ShouldRetryFn = (count) => count < 3;
+export const defaultRetryFn: ShouldRetryFn = (count) => count < 5;

--- a/packages/sync/src/utils/helpers.ts
+++ b/packages/sync/src/utils/helpers.ts
@@ -2,10 +2,18 @@ import { getMainDefinition, hasDirectives } from "apollo-utilities";
 import { Operation } from "apollo-link";
 import { localDirectives } from "../config/Constants";
 
+/**
+ * Check if operation was done when offline
+ */
 export const markOffline = (operation: Operation) => {
   operation.extensions.persistedOffline = true;
 };
 
+/**
+ * Checks if operation was scheduled to saved to offline queue.
+ * This operations have special handling.
+ * They are never forwarded when sent back again to client.
+ */
 export const markedOffline = (operation: Operation) => {
   return !!(operation.extensions.persistedOffline);
 };

--- a/packages/sync/src/utils/helpers.ts
+++ b/packages/sync/src/utils/helpers.ts
@@ -3,16 +3,11 @@ import { Operation } from "apollo-link";
 import { localDirectives } from "../config/Constants";
 
 export const markOffline = (operation: Operation) => {
-  if (typeof operation.getContext === "function") {
-    operation.setContext({ persitedOffline: true });
-  }
+  operation.extensions.persistedOffline = true;
 };
 
 export const markedOffline = (operation: Operation) => {
-  if (typeof operation.getContext === "function") {
-    return !!(operation.getContext().persitedOffline);
-  }
-  return false;
+  return !!(operation.extensions.persistedOffline);
 };
 
 export const isSubscription = (op: Operation) => {

--- a/packages/sync/src/utils/helpers.ts
+++ b/packages/sync/src/utils/helpers.ts
@@ -2,6 +2,19 @@ import { getMainDefinition, hasDirectives } from "apollo-utilities";
 import { Operation } from "apollo-link";
 import { localDirectives } from "../config/Constants";
 
+export const markOffline = (operation: Operation) => {
+  if (typeof operation.getContext === "function") {
+    operation.setContext({ persitedOffline: true });
+  }
+};
+
+export const markedOffline = (operation: Operation) => {
+  if (typeof operation.getContext === "function") {
+    return !!(operation.getContext().persitedOffline);
+  }
+  return false;
+};
+
 export const isSubscription = (op: Operation) => {
   const { kind, operation } = getMainDefinition(op.query) as any;
   return kind === "OperationDefinition" && operation === "subscription";


### PR DESCRIPTION
## Motivation

The queue should be processed when offline only.
Mutations should be marked as offline to enqueue them from offline mutation handler. Posting for early feedback. Please shout as soon as you see something wrong

## Progress

- [x] Forward online request and let them fail fast
- [x] Enable retry link for offline handler
- [x] Do not dequeue when retrylink returned error
- [x] Provide safe defaults for retry link
- [x] Connect mutation listeners to retry link
- [x] Remove config for retry link (this should be internal

## Testing

I have performed testing for all possible cases but feel free to chime in with testing.

### Cases

- Offline changes restored when server is down
- Offline changes ending up with graphql error
- Offline changes are successful. 

## Not included (separate PR) 

- [ ] Pass optimistic response when saving offline change (this will resolve the problem with disappearing optimistic responses)