### PR TITLE
Update OfflineLink.ts

### DIFF
--- a/packages/sync/src/links/OfflineLink.ts
+++ b/packages/sync/src/links/OfflineLink.ts
@@ -40,7 +40,7 @@ export class OfflineLink extends ApolloLink {
     const queueOptions = {
       ...options,
       onEnqueue: this.handleQueueChange,
-      onDequeue: this.handleQueueChange
+      onDequeue: ()=>{return;}
     };
 
     this.queue = new OfflineQueue(queueOptions);


### PR DESCRIPTION
It looks like dequeue was calling forward operation when online. 
From my way of understanding if feels that this is not needed as dequeue is called only when operation was forwarded so server. 
Any opinions?