### PR TITLE
AEROGEAR-8664

### DIFF
--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -27,12 +27,14 @@
   "homepage": "https://github.com/aerogear/aerogear-js-sdk#readme",
   "devDependencies": {
     "@types/chai": "4.1.7",
+    
     "chai": "4.2.0",
     "mocha": "6.0.2",
     "nyc": "13.3.0",
     "typescript": "3.3.3333"
   },
   "dependencies": {
-    "@aerogear/core": "2.3.0"
+    "@aerogear/core": "2.3.0",
+    "@types/loglevel": "1.5.4"
   }
 }

--- a/packages/security/src/appSecurity/AppSecurity.ts
+++ b/packages/security/src/appSecurity/AppSecurity.ts
@@ -1,0 +1,40 @@
+import console from "loglevel";
+import { ServiceConfiguration, ConfigurationService } from "@aerogear/core";
+
+export class AppSecurity {
+  private static readonly TYPE: string = "security";
+  private internalConfig: any;
+
+  constructor (config: ConfigurationService){
+    const configuration = config.getConfigByType(AppSecurity.TYPE);
+    if (configuration && configuration.length > 0) {
+      const serviceConfiguration: ServiceConfiguration = configuration[0];
+      this.internalConfig = serviceConfiguration.config;
+      // use the configuration url in the from the incoming config file
+      this.internalConfig.url = serviceConfiguration.url;
+    } else {
+      console.warn("Security configuration is missing. The Security module will not work properly.");
+    }
+  }
+  // TODO get device info AEROGEAR-8773
+
+  // TODO call init endpoint on go mobile security service AEROGEAR-8774
+
+  // TODO need to deal with data return by init AEROGEAR-8775
+
+  // TODO send enabled/disabled data to metrics AEROGEAR-8776
+
+  /**
+   * Return the config used for the Security server
+   */
+  public getConfig(): string[] {
+    return this.internalConfig;
+  }
+
+  /**
+   * Return true if config is present
+   */
+  public hasConfig(): boolean {
+    return !!this.internalConfig;
+  }
+}

--- a/packages/security/src/appSecurity/AppSecurity.ts
+++ b/packages/security/src/appSecurity/AppSecurity.ts
@@ -5,7 +5,7 @@ export class AppSecurity {
   private static readonly TYPE: string = "security";
   private internalConfig: any;
 
-  constructor (config: ConfigurationService){
+  constructor(config: ConfigurationService) {
     const configuration = config.getConfigByType(AppSecurity.TYPE);
     if (configuration && configuration.length > 0) {
       const serviceConfiguration: ServiceConfiguration = configuration[0];

--- a/packages/security/test/config/mobile-services.json
+++ b/packages/security/test/config/mobile-services.json
@@ -24,6 +24,14 @@
       "type": "push",
       "url": "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6",
       "config": {}
+    },
+    {
+      "id": "security",
+      "name": "security",
+      "type": "security",
+      "url": "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6",
+      "config": {}
     }
+
   ]
 }


### PR DESCRIPTION
# Description
https://issues.jboss.org/browse/AEROGEAR-8772
Create a class in the security-services that uses the aerogear-js-sdk init for enabling and disabling

Implementation is similar to the Auth package
### auth
https://github.com/aerogear/aerogear-js-sdk/blob/964a45b0a851720410b68958774ed0f97e7d6785/packages/auth/src/Auth.ts#L17

### push
https://github.com/aerogear/aerogear-js-sdk/blob/964a45b0a851720410b68958774ed0f97e7d6785/packages/push/src/PushRegistration.ts#L23

### sync
https://github.com/aerogear/aerogear-js-sdk/blob/964a45b0a851720410b68958774ed0f97e7d6785/packages/sync/src/config/SyncConfig.ts#L26


No Verification steps as this is a constructor 

##### Checklist

- [x] `npm test` passes

