### PR TITLE
AEROGEAR-8774 post client data to go mobile security service

### DIFF
--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@aerogear/core": "2.3.1",
-    "@types/loglevel": "1.5.4"
+    "@types/loglevel": "1.5.4",
+    "axios": "^0.18.0"
   }
 }

--- a/packages/security/src/appSecurity/AppSecurity.ts
+++ b/packages/security/src/appSecurity/AppSecurity.ts
@@ -22,7 +22,7 @@ export class AppSecurity {
   // TODO move this functionality to the core
   public getClientData = async (): Promise<any> => {
     const metricsBuilder: MetricsBuilder = new MetricsBuilder();
-    const metricsPayload: {[key: string]: any;} = {};
+    const metricsPayload: {[key: string]: any; } = {};
     const metrics = metricsBuilder.buildDefaultMetrics();
     for (const metric of metrics) {
       metricsPayload[metric.identifier] = await metric.collect();

--- a/packages/security/src/appSecurity/AppSecurity.ts
+++ b/packages/security/src/appSecurity/AppSecurity.ts
@@ -1,4 +1,4 @@
-import console from "loglevel";
+//import console from "loglevel";
 import { ServiceConfiguration, ConfigurationService, MetricsBuilder } from "@aerogear/core";
 
 export class AppSecurity {
@@ -33,6 +33,20 @@ export class AppSecurity {
   }
 
   // TODO call init endpoint on go mobile security service AEROGEAR-8774
+  public clientInit() {
+    this.getClientData()
+    .then(metricsPayload => {
+      const initPayload: {[key: string]: any; } = {};
+      // build the initPayload
+      initPayload.deviceId = metricsPayload.clientID;
+      initPayload.appId = metricsPayload.app.appId,
+      initPayload.deviceType = metricsPayload.device.platform;
+      initPayload.deviceVersion = metricsPayload.device.platformVersion;
+      initPayload.version = metricsPayload.app.appVersion;
+      console.log(initPayload);
+      return "initPayload";
+    });
+  }
 
   // TODO need to deal with data return by init AEROGEAR-8775
 

--- a/packages/security/src/appSecurity/AppSecurity.ts
+++ b/packages/security/src/appSecurity/AppSecurity.ts
@@ -31,7 +31,7 @@ export class AppSecurity {
     return metricsPayload;
   }
 
-  // TODO call init endpoint on go mobile security service AEROGEAR-8774
+  // Call the init endpoint on go mobile security service AEROGEAR-8774
   public clientInit(): Promise<any> {
     const clientInitResponse = this.getClientData()
     .then(metricsPayload => {
@@ -46,10 +46,6 @@ export class AppSecurity {
     });
     return clientInitResponse;
   }
-
-  // TODO need to deal with data return by init AEROGEAR-8775
-
-  // TODO send enabled/disabled data to metrics AEROGEAR-8776
 
   /**
    * Return the config used for the Security server

--- a/packages/security/src/appSecurity/AppSecurity.ts
+++ b/packages/security/src/appSecurity/AppSecurity.ts
@@ -1,4 +1,5 @@
-//import console from "loglevel";
+import console from "loglevel";
+import axios from "axios";
 import { ServiceConfiguration, ConfigurationService, MetricsBuilder } from "@aerogear/core";
 
 export class AppSecurity {
@@ -21,9 +22,7 @@ export class AppSecurity {
   // TODO move this functionality to the core
   public getClientData = async (): Promise<any> => {
     const metricsBuilder: MetricsBuilder = new MetricsBuilder();
-    const metricsPayload: {
-      [key: string]: any;
-    } = {};
+    const metricsPayload: {[key: string]: any;} = {};
     const metrics = metricsBuilder.buildDefaultMetrics();
     for (const metric of metrics) {
       metricsPayload[metric.identifier] = await metric.collect();
@@ -33,8 +32,8 @@ export class AppSecurity {
   }
 
   // TODO call init endpoint on go mobile security service AEROGEAR-8774
-  public clientInit() {
-    this.getClientData()
+  public clientInit(): Promise<any> {
+    const clientInitResponse = this.getClientData()
     .then(metricsPayload => {
       const initPayload: {[key: string]: any; } = {};
       // build the initPayload
@@ -43,9 +42,9 @@ export class AppSecurity {
       initPayload.deviceType = metricsPayload.device.platform;
       initPayload.deviceVersion = metricsPayload.device.platformVersion;
       initPayload.version = metricsPayload.app.appVersion;
-      console.log(initPayload);
-      return "initPayload";
+      return axios.post(this.internalConfig.url, initPayload);
     });
+    return clientInitResponse;
   }
 
   // TODO need to deal with data return by init AEROGEAR-8775

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -1,4 +1,4 @@
 export * from "./deviceTrust";
 export * from "./metrics";
 export { SecurityService } from "./SecurityService";
-export { AppSecurity } from "./appSecurity/AppSecurity"
+export { AppSecurity } from "./appSecurity/AppSecurity";


### PR DESCRIPTION
### Description
Merging to feature branch `app-security`
# What
PR Post modified device data and app data to the security services app-service module

# How
returns a promise from axios

# Why
Needed for the Mobile security service Go server app-security integration
https://issues.jboss.org/browse/AEROGEAR-8774

# Verification
## Prerequisites 
- node 10
- npm 6
- install ionic https://ionicframework.com/docs/installation/cli
- install android sdk 26 http://www.androiddocs.com/sdk/installing/adding-packages.html

## Steps
- clone this repo
- checkout branch AEROGEAR-8774
- install the aerogear-js-sdk
```bash
npm i && npm run bootstrap && npm run build
```

- clone https://github.com/austincunningham/ionic-showcase.git
- checkout branch AEROGEAR-8773
- change the package.json to point at your local clone of aerogear-js-sdk e.g.

![image](https://user-images.githubusercontent.com/16667688/54757368-f6b08880-4be1-11e9-80fc-fa145fafca42.png)

> Note you can try and use npm link but I didn't have much joy with it 
- install ionic-showcase
```
npm i
```
- build the android apk
```
ionic cordova build android
```
- copy the apk to your android device emulation
- open the app on the emulator
- follow these steps to attach your chrome developer console to your emulation https://developers.google.com/web/tools/chrome-devtools/remote-debugging/

- start the mobile security services db as outline here https://github.com/aerogear/mobile-security-service#131-by-using-the-docker-image-of-this-project
- start the go mobile security service as outline here https://github.com/aerogear/mobile-security-service#14-starting-the-server

- add the app to the app table
set the `id` field with a uuid you can generate one here https://www.uuidgenerator.net/
set the `app_id` with `org.aerogear.ionic.showcase`
set the `app_name` to any string

- In the console you should see the INIT Data and the metrics payload to verify this

![image](https://user-images.githubusercontent.com/16667688/54926054-7488d280-4f07-11e9-9a0e-f10e8b7e84d4.png)

##### Checklist


- [x] `npm test` passes
- [x] `npm run build` works
