### PR TITLE
feat: added retryLink for offline queued mutation failures

### DIFF
--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -53,6 +53,7 @@
     "apollo-link-context": "1.0.17",
     "apollo-link-error": "1.1.10",
     "apollo-link-http": "1.5.14",
+    "apollo-link-retry": "^2.2.13",
     "apollo-link-ws": "1.0.17",
     "apollo-upload-client": "10.0.0",
     "debug": "4.1.1",

--- a/packages/sync/src/config/DataSyncConfig.ts
+++ b/packages/sync/src/config/DataSyncConfig.ts
@@ -6,6 +6,7 @@ import { ObjectState } from "../conflicts/ObjectState";
 import { ConflictListener } from "../conflicts/ConflictListener";
 import { ConfigurationService } from "@aerogear/core";
 import CacheUpdates from "../cache/CacheUpdates";
+import { RetryLink } from "apollo-link-retry";
 
 /**
  * Contains all configuration options required to initialize Voyager Client
@@ -108,4 +109,12 @@ export interface DataSyncConfig {
    * Argument allows to restore optimistic responses on application restarts.
    */
   mutationCacheUpdates?: CacheUpdates;
+
+  /**
+   * [Modifier]
+   *
+   * The options to configure how failed offline mutations are retried.
+   *
+   */
+  retryOptions?: RetryLink.Options;
 }

--- a/packages/sync/src/config/SyncConfig.ts
+++ b/packages/sync/src/config/SyncConfig.ts
@@ -45,6 +45,17 @@ export class SyncConfig implements DataSyncConfig {
   public conflictStrategy: ConflictResolutionStrategies;
   public conflictStateProvider = new VersionedState();
 
+  public retryOptions = {
+    delay: {
+      initial: 1000,
+      max: Infinity,
+      jitter: true
+    },
+    attempts: {
+      max: 5
+    }
+  };
+
   public networkStatus: NetworkStatus;
   private readonly clientConfig: DataSyncConfig;
 

--- a/packages/sync/test/SyncConfigTest.ts
+++ b/packages/sync/test/SyncConfigTest.ts
@@ -24,7 +24,7 @@ describe("OnOffLink", () => {
     const config = new SyncConfig(userConfig);
     const mergedConfig = config.getClientConfig();
     expect(mergedConfig.httpUrl).eq(userConfig.httpUrl);
-    expect(mergedConfig.retryOptions.attempts).eq(userConfig.retryOptions.attempts);
+    expect(mergedConfig.retryOptions).eq(userConfig.retryOptions);
   });
 
   it("validates config", () => {

--- a/packages/sync/test/SyncConfigTest.ts
+++ b/packages/sync/test/SyncConfigTest.ts
@@ -10,7 +10,7 @@ global.window = {};
 
 describe("OnOffLink", () => {
 
-  const userConfig = { httpUrl: "test" };
+  const userConfig = { httpUrl: "test", retryOptions: { attempts: { max: 10 } } };
   const configWithConflictDictionary: DataSyncConfig = {
     httpUrl: "test",
     conflictStrategy: {
@@ -24,6 +24,7 @@ describe("OnOffLink", () => {
     const config = new SyncConfig(userConfig);
     const mergedConfig = config.getClientConfig();
     expect(mergedConfig.httpUrl).eq(userConfig.httpUrl);
+    expect(mergedConfig.retryOptions.attempts).eq(userConfig.retryOptions.attempts);
   });
 
   it("validates config", () => {


### PR DESCRIPTION
### Description

added the apollo retry link to retry mutations which have failed and were previously queued offline.

### Verification
1. Go offline
1. Create a couple of mutations
1. Stop the server
1. Go back online
1. Mutations should be attempted to be replayed after 1 second and should be retried 5 times. If they are unsuccessful they should remain in the queue. If they are successful they should be removed from the offline queue. 

##### Checklist

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
