### PR TITLE
Aerogear-8911 refactor to use metrics service

### DIFF
--- a/packages/core/src/metrics/index.ts
+++ b/packages/core/src/metrics/index.ts
@@ -1,4 +1,4 @@
 export * from "./MetricsService";
-export * from "./MetricsBuilder";
+export * from "./DefaultMetricsBuilder";
 export * from "./model";
 export * from "./publisher";

--- a/packages/core/src/metrics/model/MetricsBuilder.ts
+++ b/packages/core/src/metrics/model/MetricsBuilder.ts
@@ -1,0 +1,33 @@
+import { Metrics } from "./Metrics";
+import { MetricsPayload } from "./MetricsPayload";
+
+export interface MetricsBuilder {
+  /**
+   * Generates or gets mobile client id
+   */
+  getClientId(): string;
+
+  /**
+   * Getter for getting the client id from storage
+   */
+  getSavedClientId(): string | null;
+  /**
+   * Setter for saving the client id to storage
+   * @param id string typically UUID
+   */
+  saveClientId(id: string): void;
+
+  /**
+   * Builds array of default metrics objects that are sent to server on every request.
+   * Other platforms can override this method to provide custom behavior
+   */
+  buildDefaultMetrics(): Metrics[];
+
+  /**
+   * Builds the metrics payload
+   * @param type string
+   * @param metrics Metrics array
+   * returns promise with metrics payload
+   */
+  buildMetricsPayload(type: string, metrics: Metrics[]): Promise<MetricsPayload>;
+}

--- a/packages/core/src/metrics/model/index.ts
+++ b/packages/core/src/metrics/model/index.ts
@@ -2,3 +2,4 @@ export { AppMetrics } from "./AppMetrics";
 export { DeviceMetrics } from "./DeviceMetrics";
 export { Metrics } from "./Metrics";
 export { MetricsPayload } from "./MetricsPayload";
+export { MetricsBuilder } from "./MetricsBuilder";

--- a/packages/core/test/metrics/MetricsBuilderTest.ts
+++ b/packages/core/test/metrics/MetricsBuilderTest.ts
@@ -1,5 +1,5 @@
 import {assert} from "chai";
-import {MetricsBuilder} from "../../src/metrics";
+import {MetricsBuilder, DefaultMetricsBuilder} from "../../src/metrics";
 
 declare var window: any;
 declare var global: any;
@@ -34,7 +34,7 @@ describe("MetricsBuilder", () => {
   let metricsBuilder: MetricsBuilder;
 
   beforeEach(() => {
-    metricsBuilder = new MetricsBuilder(localStorage);
+    metricsBuilder = new DefaultMetricsBuilder(localStorage);
     storage.aerogear_metrics_client_key = "";
   });
 

--- a/packages/core/test/metrics/MetricsServiceTest.ts
+++ b/packages/core/test/metrics/MetricsServiceTest.ts
@@ -1,8 +1,18 @@
-import { assert, expect } from "chai";
+import chai from "chai";
+import chaiPromises from "chai-as-promised";
 import sinon from "sinon";
-import { Metrics, MetricsPayload, MetricsPublisher, MetricsService, NetworkMetricsPublisher } from "../../src/metrics";
+import {
+  Metrics,
+  MetricsPayload,
+  MetricsPublisher,
+  MetricsService,
+  NetworkMetricsPublisher,
+  MetricsBuilder
+} from "../../src/metrics";
 import testAerogearConfig from "../mobile-config.json";
-import { MetricsBuilder } from "../../src/metrics/MetricsBuilder";
+import { DefaultMetricsBuilder } from "../../src/metrics/DefaultMetricsBuilder";
+
+chai.use(chaiPromises);
 
 declare var global: any;
 declare var window: any;
@@ -39,13 +49,13 @@ describe("MetricsService", () => {
     it("should instantiate NetworkMetricsPublisher with configuration url", () => {
       const publisher = metricsService.metricsPublisher as NetworkMetricsPublisher;
 
-      assert.equal((metricsConfig as any).url, publisher.url);
+      chai.assert.equal((metricsConfig as any).url, publisher.url);
     });
 
     it("should not throw an error when not being able to publish default metrics", () => {
       const test = () => new MetricsService({ configuration: testAerogearConfig, builder: metricsBuilder });
 
-      expect(test).to.not.throw();
+      chai.expect(test).to.not.throw();
     });
 
   });
@@ -118,22 +128,22 @@ describe("MetricsService", () => {
     });
 
     it("should throw an error if type is null", () => {
-      const test = () => metricsService.publish(null as unknown as string, []);
+      const test = metricsService.publish(null as unknown as string, []);
 
-      expect(test).to.throw("Type is invalid: null");
+      chai.expect(test).to.rejectedWith("Type is invalid: null");
     });
 
     it("should throw an error if type is undefined", () => {
-      const test = () => metricsService.publish(undefined as unknown as string, []);
+      const test = metricsService.publish(undefined as unknown as string, []);
 
-      expect(test).to.throw("Type is invalid: undefined");
+      chai.expect(test).to.rejectedWith("Type is invalid: undefined");
     });
 
     it("should not throw an error if publisher is undefined", () => {
       metricsService.metricsPublisher = undefined;
       const test = () => metricsService.publish("type", []);
 
-      expect(test).to.not.throw();
+      chai.expect(test).to.not.throw();
     });
 
   });
@@ -156,7 +166,7 @@ describe("MetricsService", () => {
     }
   }
 
-  class MockMetricsBuilder extends MetricsBuilder {
+  class MockMetricsBuilder extends DefaultMetricsBuilder {
 
     public getSavedClientId(): string {
       return "THE_CLIENT_ID";

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -29,11 +29,14 @@
     "@types/chai": "4.1.7",
     "chai": "4.2.0",
     "mocha": "6.0.2",
-    "typescript": "3.4.1"
+    "mockttp": "^0.13.0",
+    "nyc": "13.3.0",
+    "typescript": "3.3.3333"
   },
   "dependencies": {
     "@aerogear/core": "2.3.1",
     "@types/loglevel": "1.5.4",
-    "axios": "^0.18.0"
+    "axios": "^0.18.0",
+    "loglevel": "^1.6.1"
   }
 }

--- a/packages/security/src/appSecurity/AppSecurity.ts
+++ b/packages/security/src/appSecurity/AppSecurity.ts
@@ -19,7 +19,7 @@ export class AppSecurity {
 
   constructor(config: ConfigurationService, options?: AppSecurityOptions) {
     if (!isMobileCordova()) {
-      throw new Error("Cordova Platform Not Detected. This module should not be used.");
+      console.error("Cordova Platform Not Detected. This module should not be used.");
     }
 
     this.metricsBuilder = (options && options.metricsBuilder) ? options.metricsBuilder : new DefaultMetricsBuilder();

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -1,4 +1,4 @@
 export * from "./deviceTrust";
 export * from "./metrics";
 export { SecurityService } from "./SecurityService";
-export { AppSecurity } from "./appSecurity/AppSecurity";
+export * from "./appSecurity/AppSecurity";

--- a/packages/security/test/AppSecurityTest.ts
+++ b/packages/security/test/AppSecurityTest.ts
@@ -1,0 +1,101 @@
+import { assert } from "chai";
+import mocha, { test } from "mocha";
+import * as mockttp from "mockttp";
+import { ConfigurationService, MetricsPayload, MetricsBuilder, Metrics, AeroGearConfiguration } from "@aerogear/core";
+
+import { AppSecurity } from "../src";
+
+declare var window: any;
+declare var global: any;
+
+global.window = {};
+window.device = {};
+window.cordova = {};
+
+class MockMetricsBuilder implements MetricsBuilder {
+  public payload: MetricsPayload;
+
+  constructor(payload: MetricsPayload) {
+    this.payload = payload;
+  }
+
+  public getClientId(): string {
+    return "";
+  }
+
+  public getSavedClientId(): string | null {
+    return "";
+  }
+
+  public saveClientId(id: string): void {
+    return;
+  }
+
+  public buildDefaultMetrics(): Metrics[] {
+    return [];
+  }
+
+  public buildMetricsPayload(type: string, metrics: Metrics[]): Promise<MetricsPayload> {
+    return new Promise((resolve, reject) => {
+      resolve(this.payload);
+    });
+  }
+}
+
+describe("AppSecurity", () => {
+
+  let testAerogearConfig: AeroGearConfiguration;
+
+  const validMetrics: MetricsPayload = {
+    clientId: "123",
+    type: "init",
+    data: {
+      app: {
+        appId: "org.aerogear.ionic.showcase",
+        appVersion: "0.0.1"
+      },
+      device: {
+        platform: "android",
+        platformVersion: "8.0.0"
+      }
+    }
+  };
+
+  const mockServer = mockttp.getLocal();
+
+  before(async () => {
+    await mockServer.start();
+    await mockServer.post("/api/init").thenReply(204);
+
+    testAerogearConfig = {
+      "version": 1.0,
+      "clusterName": "192.168.64.74:8443",
+      "namespace": "myproject",
+      "services": [
+        {
+          "id": "security",
+          "name": "security",
+          "type": "security",
+          "url": mockServer.url,
+          "config": {}
+        }
+      ]
+    };
+  });
+
+  after(() => {
+    mockServer.stop();
+  });
+
+  describe("clientInit", () => {
+
+    it("should return 204 if clientInit POST successful", async () => {
+      const configService = new ConfigurationService(testAerogearConfig);
+      const appSecurity = new AppSecurity(configService, { metricsBuilder: new MockMetricsBuilder(validMetrics)});
+      const res = await appSecurity.clientInit();
+
+      assert.equal(res.status, 204);
+    });
+
+  });
+});

--- a/packages/sync/src/links/LinksBuilder.ts
+++ b/packages/sync/src/links/LinksBuilder.ts
@@ -5,7 +5,7 @@ import { conflictLink } from "../conflicts";
 import { DataSyncConfig } from "../config";
 import { createAuthLink } from "./AuthLink";
 import { AuditLoggingLink } from "./AuditLoggingLink";
-import { MetricsBuilder } from "@aerogear/core";
+import { DefaultMetricsBuilder, MetricsBuilder } from "@aerogear/core";
 import { LocalDirectiveFilterLink } from "./LocalDirectiveFilterLink";
 import { createUploadLink } from "apollo-upload-client";
 import { isMutation, isOnlineOnly, isSubscription, isMarkedOffline } from "../utils/helpers";
@@ -93,7 +93,7 @@ export const defaultHttpLinks = async (config: DataSyncConfig, offlineLink: Apol
 };
 
 const createAuditLoggingLink = async (): Promise<AuditLoggingLink> => {
-  const metricsBuilder: MetricsBuilder = new MetricsBuilder();
+  const metricsBuilder: MetricsBuilder = new DefaultMetricsBuilder();
   const metricsPayload: {
     [key: string]: any;
   } = {};


### PR DESCRIPTION
### Description
Merging to feature branch `app-security`
# What
PR uses the metrics services with new publisher to post metrics data

# How
returns a promise

# Why
Needed for the Mobile security service Go server app-security integration
https://issues.jboss.org/browse/AEROGEAR-8911

# Verification
## Prerequisites 
- node 10
- npm 6
- install ionic https://ionicframework.com/docs/installation/cli
- install android sdk 26 http://www.androiddocs.com/sdk/installing/adding-packages.html
- cordova 8.1.2

## Steps
- clone this repo
- checkout branch AEROGEAR-8911
- install the aerogear-js-sdk
```bash
npm i && npm run bootstrap && npm run build
```

- clone https://github.com/austincunningham/ionic-showcase.git
- checkout branch AEROGEAR-8773
- change the package.json to point at your local clone of aerogear-js-sdk e.g.

![image](https://user-images.githubusercontent.com/16667688/54757368-f6b08880-4be1-11e9-80fc-fa145fafca42.png)

> Note you can try and use npm link but I didn't have much joy with it 
- install ionic-showcase
```
npm i
```
- build the android apk
```
ionic cordova build android
```
- copy the apk to your android device emulation
- open the app on the emulator
- follow these steps to attach your chrome developer console to your emulation https://developers.google.com/web/tools/chrome-devtools/remote-debugging/

- start the mobile security services db as outline here https://github.com/aerogear/mobile-security-service#131-by-using-the-docker-image-of-this-project
- start the go mobile security service as outline here https://github.com/aerogear/mobile-security-service#14-starting-the-server

- add the app to the app table
set the `id` field with a uuid you can generate one here https://www.uuidgenerator.net/
set the `app_id` with `org.aerogear.ionic.showcase`
set the `app_name` to any string

- In the console you should see the INIT Data and the metrics payload to verify this

![image](https://user-images.githubusercontent.com/16667688/54926054-7488d280-4f07-11e9-9a0e-f10e8b7e84d4.png)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included

