### PR TITLE
fix: pass auth header in connection params in websocket link

### DIFF
--- a/packages/sync/src/links/WebsocketLink.ts
+++ b/packages/sync/src/links/WebsocketLink.ts
@@ -9,8 +9,8 @@ export const defaultWebSocketLink = (userOptions: DataSyncConfig, config: WebSoc
       // Params that can be used to send authentication token etc.
       connectionParams: async () => {
         if (userOptions.authContextProvider) {
-          const { token } = await userOptions.authContextProvider();
-          return token;
+          const { header } = await userOptions.authContextProvider();
+          return { Authorization: header };
         }
       },
       connectionCallback: options.connectionCallback,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/aerogear/aerogear-js-sdk/blob/master/CONTRIBUTING.md
-->

### Description

Related PRs:

* https://github.com/aerogear/ionic-showcase/pull/175
* https://github.com/aerogear/voyager-server/pull/164

This PR makes a tiny change so the full `Authorization` header is sent in the `connectionParams` for the WebSocketLink. The reason to do it this way is because it's compatible with things like GraphQL playground / Altair as well. This means we can do subscriptions + keycloak properly from those environments also.

### How `connectionParams` works under the hood

I had to research this a little bit because I wasn't sure how the data is being sent and parsed on the server side.

It turns out once the websocket connection is negotiated an initial message is sent from the client to the server to say hello. The payload of that message is usually empty but if a `connectionParams` is provided it will be sent and on the server side it is parsed and will be available inside the `onConnect` function. The payload can be any string value but the server will attempt to parse it as JSON. The format introduced by this PR is the best approach.

### Questions That Need to be Answered

What happens when the token expires? According to some people you should be calling `socket.close()` every time you refresh your token on the client side and then the client will automatically reconnect using the new token if you have the `reconnect` option set to `true`. [This particular comment](https://github.com/apollographql/subscriptions-transport-ws/issues/171#issuecomment-348492358) mentions that but the entire discussion there is very good.

The problem is we do not have access to that web socket client so I'm not 100% sure on how the behaviour should work.

On top of that, the current server implementation I have only checks the token once when the client connects so right now I think it's possible that the client could connect with a good token. Then when that token expires, the client could stay connected. Of course, if the connection breaks and they try to reconnect they will be forced to find a new token.

Again, in the discussion I linked, some people suggest checking the token in `onOperation` on the server side however, many have complained that it causes serious performance problems as the token is now being checked on every single message sent over the socket.

@wtrocki I'd love to get your thoughts on it.

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
