### PR TITLE
Subscribe alias topic

### DIFF
--- a/packages/push/src/PushRegistration.ts
+++ b/packages/push/src/PushRegistration.ts
@@ -37,7 +37,7 @@ export class PushRegistration {
    * @param categories array list of categories that device should be register to.
    */
   public register(deviceToken: string, alias: string = "", categories: string[] = []): Promise<void> {
-    if (!window || !window.device) {
+    if (!window || !window.device || !window.PushNotification) {
       return Promise.reject(new Error("Registration requires cordova plugin. Verify the " +
         "@aerogear/cordova-plugin-aerogear-push plugin is installed."));
     }

--- a/packages/push/src/PushRegistration.ts
+++ b/packages/push/src/PushRegistration.ts
@@ -107,16 +107,11 @@ export class PushRegistration {
       .then(
         () => {
           if (isCordovaAndroid()) {
-            this._objectInstance.subscribe(
-              variantId,
-              () => {
-                resolve();
-              },
-              (e: any) => {
-                console.warn("error:", e);
-                reject();
-              }
-            );
+            this.subscribeToFirebaseTopic(variantId);
+            for (const category of categories) {
+              this.subscribeToFirebaseTopic(category);
+            }
+            resolve();
           } else {
             resolve();
           }
@@ -139,4 +134,17 @@ export class PushRegistration {
   public hasConfig(): boolean {
     return !!this.pushConfig;
   }
+
+  private subscribeToFirebaseTopic(topic: string) {
+    this._objectInstance.subscribe(
+      topic,
+      () => {
+        console.warn("FCM topic: " + topic + " subscribed");
+      },
+      (e: any) => {
+        console.warn("error:", e);
+      }
+    );
+  }
+
 }

--- a/packages/push/src/PushRegistration.ts
+++ b/packages/push/src/PushRegistration.ts
@@ -111,10 +111,8 @@ export class PushRegistration {
             for (const category of categories) {
               this.subscribeToFirebaseTopic(category);
             }
-            resolve();
-          } else {
-            resolve();
           }
+          resolve();
         }
       )
       .catch(reject);

--- a/packages/push/test/PushRegistrationTest.ts
+++ b/packages/push/test/PushRegistrationTest.ts
@@ -1,11 +1,12 @@
-import { assert, expect } from "chai";
-import { PushRegistration } from "../src/PushRegistration";
+import { assert } from "chai";
+import { PushRegistration } from "../src";
 import { ConfigurationService } from "@aerogear/core";
 
 declare var window: any;
 declare var global: any;
 
 global.window = { btoa: () => "dGVzdA==" };
+global.window.PushNotification = { init: () => "" };
 window.device = { platform: "iOS" };
 
 describe("Registration tests", () => {

--- a/packages/push/test/indexTest.ts
+++ b/packages/push/test/indexTest.ts
@@ -1,6 +1,0 @@
-import { assert, expect } from "chai";
-import mocha from "mocha";
-
-describe("Test app  module", () => {
-  it("Add tests here");
-});


### PR DESCRIPTION
When app is running on Android devices, subscribe the it in the Firebase Cloud Messaging topics using the UnifiedPush Server VariandID, and the categories used in the registration process. That is how UnifiedPush Server send message to the Android devices using no criteria and a specifically category name.

PS: There is more work to be done like add a unregistered method but it will be done in another issues/PR

Related Issue:

* [AEROGEAR-9176](https://issues.jboss.org/browse/AEROGEAR-9176)

## Screenshots

**Sending message for all devices**

<img width="1440" alt="Screenshot 2019-05-20 09 50 20" src="https://user-images.githubusercontent.com/13337/58023802-1d5a4500-7ae7-11e9-867f-e3310e122ea7.png">

**Sending message for an specifically alias**

<img width="1440" alt="Screenshot 2019-05-20 09 50 45" src="https://user-images.githubusercontent.com/13337/58023834-2f3be800-7ae7-11e9-87da-8b79c7120a75.png">

**Sending message for an specifically category** 

<img width="1440" alt="Screenshot 2019-05-20 09 51 08" src="https://user-images.githubusercontent.com/13337/58023837-33680580-7ae7-11e9-81bb-54af096a9507.png">

This requires [this PR](https://github.com/aerogear/ionic-showcase/pull/182)

