### PR TITLE
fix: expose update function

### DIFF
--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -62,6 +62,7 @@
     "graphql-tag": "2.10.1",
     "graphql-tools": "4.0.4",
     "idb-localstorage": "0.2.0",
-    "subscriptions-transport-ws": "0.9.16"
+    "subscriptions-transport-ws": "0.9.16",
+    "util": "^0.12.0"
   }
 }

--- a/packages/sync/src/cache/createMutationOptions.ts
+++ b/packages/sync/src/cache/createMutationOptions.ts
@@ -37,10 +37,12 @@ export const createMutationOptions = (options: MutationHelperOptions): MutationO
   const update: MutationUpdaterFn = (cache, { data }) => {
     if (isArray(updateQuery)) {
       for (const query of updateQuery) {
-        getUpdateFunction(operationName, idField, query, operationType)(cache, { data });
+        const updateFunction = getUpdateFunction(operationName, idField, query, operationType);
+        updateFunction(cache, { data });
       }
     } else {
-      getUpdateFunction(operationName, idField, updateQuery, operationType)(cache, { data });
+      const updateFunction = getUpdateFunction(operationName, idField, updateQuery, operationType);
+      updateFunction(cache, { data });
     }
   };
 

--- a/packages/sync/src/cache/createMutationOptions.ts
+++ b/packages/sync/src/cache/createMutationOptions.ts
@@ -36,9 +36,9 @@ export const createMutationOptions = (options: MutationHelperOptions): MutationO
 
   const update: MutationUpdaterFn = (cache, { data }) => {
     if (isArray(updateQuery)) {
-      updateQuery.forEach(query => {
+      for (const query of updateQuery) {
         getUpdateFunction(operationName, idField, query, operationType)(cache, { data });
-      });
+      }
     } else {
       getUpdateFunction(operationName, idField, updateQuery, operationType)(cache, { data });
     }

--- a/packages/sync/src/cache/createMutationOptions.ts
+++ b/packages/sync/src/cache/createMutationOptions.ts
@@ -40,7 +40,7 @@ export const createMutationOptions = (options: MutationHelperOptions): MutationO
 // returns the update function used to update the cache by the client
 // ignores the scenario where the cache operation is an update as this is handled automatically
 // from Apollo client 2.5 onwards.
-const getUpdateFunction = (
+export const getUpdateFunction = (
   operation: string,
   idField: string,
   updateQuery: Query,

--- a/packages/sync/src/cache/createMutationOptions.ts
+++ b/packages/sync/src/cache/createMutationOptions.ts
@@ -14,6 +14,10 @@ export interface MutationHelperOptions {
   idField?: string;
 }
 
+/**
+ * Returns an Apollo Client mutate compatible set of options.
+ * @param options see `MutationHelperOptions`
+ */
 export const createMutationOptions = (options: MutationHelperOptions): MutationOptions => {
   const {
     mutation,
@@ -37,9 +41,15 @@ export const createMutationOptions = (options: MutationHelperOptions): MutationO
   return { mutation, variables, optimisticResponse, update };
 };
 
-// returns the update function used to update the cache by the client
-// ignores the scenario where the cache operation is an update as this is handled automatically
-// from Apollo client 2.5 onwards.
+/**
+ * Generate the update function to update the cache for a given operation and query.
+ * Ignores the scenario where the cache operation is an update as this is handled automatically
+ * from Apollo Client 2.5 onwards.
+ * @param operation The title of the operation being performed
+ * @param idField The id field the item keys off
+ * @param updateQuery The Query to update in the cache
+ * @param opType The type of operation being performed
+ */
 export const getUpdateFunction = (
   operation: string,
   idField: string,

--- a/packages/sync/src/cache/createSubscriptionOptions.ts
+++ b/packages/sync/src/cache/createSubscriptionOptions.ts
@@ -11,6 +11,11 @@ export interface SubscriptionHelperOptions {
   idField?: string;
 }
 
+/**
+ * Helper function which can be used to call subscribeToMore for multiple SubscriptionHelperOptions
+ * @param observableQuery the query which you would like to call subscribeToMore on.
+ * @param arrayOfHelperOptions the array of `SubscriptionHelperOptions`
+ */
 export const subscribeToMoreHelper = (observableQuery: ObservableQuery,
                                       arrayOfHelperOptions: SubscriptionHelperOptions[]) => {
   for (const option of arrayOfHelperOptions) {
@@ -18,6 +23,11 @@ export const subscribeToMoreHelper = (observableQuery: ObservableQuery,
   }
 };
 
+/**
+ * Creates a SubscribeToMoreOptions object which can be used with Apollo Client's subscribeToMore function
+ * on an observable query.
+ * @param options see `SubscriptionHelperOptions`
+ */
 export const createSubscriptionOptions = (options: SubscriptionHelperOptions): SubscribeToMoreOptions => {
   const {
     subscriptionQuery,
@@ -53,6 +63,11 @@ export const createSubscriptionOptions = (options: SubscriptionHelperOptions): S
   };
 };
 
+/**
+ * Generate the standard update function to update the cache for a given operation type and query.
+ * @param opType The type of operation being performed
+ * @param idField The id field the item keys off
+ */
 export const getUpdateQueryFunction = (opType: CacheOperation, idField = "id"): UpdateFunction => {
   let updateFunction: UpdateFunction;
 

--- a/packages/sync/test/mock/mutations.ts
+++ b/packages/sync/test/mock/mutations.ts
@@ -8,6 +8,14 @@ mutation createItem($title: String!){
   }
 `;
 
+export const CREATE_LIST = gql`
+mutation createList($title: String!){
+    createList(title: $title){
+      title
+    }
+  }
+`;
+
 export const DELETE_ITEM = gql`
 mutation deleteItem($id: ID!){
     deleteItem(id: $id){
@@ -16,9 +24,35 @@ mutation deleteItem($id: ID!){
   }
 `;
 
+export const DOESNT_EXIST = gql`
+mutation somethingFake($id: ID!){
+    somethingFake(id: $id){
+      title
+    }
+  }
+`;
+
 export const GET_ITEMS = gql`
   query allItems($first: Int) {
     allItems(first: $first) {
+      id
+      title
+    }
+}
+`;
+
+export const GET_LISTS = gql`
+  query allLists($first: Int) {
+    allLists(first: $first) {
+      id
+      title
+    }
+}
+`;
+
+export const GET_NON_EXISTENT = gql`
+  query somethingFake($first: Int) {
+    somethingFake(first: $first) {
       id
       title
     }


### PR DESCRIPTION
### Description

This PR does two things.

1. Need to expose the getUpdateFunction so that a developer can manually generate cache update functions. Main usage is for storing cache update functions across device restarts.
see: https://github.com/aerogear/ionic-showcase/pull/183/files#diff-f8726a2856d5cf9931bf35cf2e8280a4R15 

2. It changes the interface so that `createMutationOptions` can now accept an array of type `Query` as well as a single Query.

The function signature is now one of the following:

```
createMutationOptions({
  mutation: DocumentNode,
  variables: OperationVariables,
  updateQuery: { query: GET_TASKS, variables: {...} },
  typeName: string,
  operationType: CacheOperation,
  idField: string
});

createMutationOptions({
  mutation: DocumentNode,
  variables: OperationVariables,
  updateQuery: [ 
     { query: GET_TASKS, variables: {...} } ,
     { query: OTHER_QUERY, variables: {...} } 
  ],
  typeName: string,
  operationType: CacheOperation,
  idField: string
});
```
Docs PR in progress: https://github.com/aerogear/mobile-docs/pull/699

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
