### PR TITLE
[PoC] add poc of client diff

### DIFF
--- a/packages/sync/src/OfflineClient.ts
+++ b/packages/sync/src/OfflineClient.ts
@@ -62,7 +62,7 @@ export class OfflineClient implements ListenerProvider {
     await this.store.init();
     const cache = await buildCachePersistence(this.config.cacheStorage);
     const offlineLink = await createOfflineLink(this.config, this.store);
-    const link = await createDefaultLink(this.config, offlineLink);
+    const link = await createDefaultLink(this.config, offlineLink, cache);
 
     const client = new ApolloClient({
       link,

--- a/packages/sync/src/links/DiffLink.ts
+++ b/packages/sync/src/links/DiffLink.ts
@@ -1,0 +1,46 @@
+import { ApolloLink, NextLink, Operation } from "apollo-link";
+import ApolloClient from "apollo-client";
+import { NormalizedCacheObject, InMemoryCache } from "apollo-cache-inmemory";
+import gql from "graphql-tag";
+
+export interface DiffableOperationVariables {
+  id: string;
+  version: number;
+  [key: string]: any;
+}
+
+export class DiffLink extends ApolloLink {
+
+  constructor(private cache: InMemoryCache) {
+    super();
+  }
+
+  public request(operation: Operation, forward?: NextLink) {
+    const diffableOperation = operation.variables as DiffableOperationVariables;
+    const topLevelId = diffableOperation.id;
+    const topLevelVersion = diffableOperation.version;
+    // const cachedObject = wojciechsMethod();
+    const fragment = gql`
+          fragment cacheTask on Task {
+            title
+            description
+            status
+          }
+        `;
+    const id = `Task:${operation.variables.id}`;
+    const cachedObject = this.cache.readFragment({ fragment, id }, false) as any;
+    const newVars: any = {};
+    if (cachedObject) {
+      for (const key in cachedObject) {
+        if (diffableOperation[key] !== undefined && (cachedObject[key] !== diffableOperation[key])) {
+          newVars[key] = diffableOperation[key];
+        }
+      }
+      operation.variables = { ...newVars, id: topLevelId, version: topLevelVersion };
+    }
+    if (!forward) {
+      return null;
+    }
+    return forward(operation);
+  }
+}


### PR DESCRIPTION
### Description

This is a PoC to prove that it is possible to strip unchanged fields from the client's operation before being sent. It makes some heavy assumptions:

* We can easily access the base for the object being mutated from the cache. Currently this relies on creating a graphql query/fragment which we shouldn't need. See: https://github.com/apollographql/apollo-client/issues/4877
* Uses a the showcase app's known schema so will not work with anything but that at the moment. See below.
* When the above fragment is removed it assumes there will be a method available which will return the whole object using just the __typename and id fields.