### PR TITLE
increased timeout for push-registration test

### DIFF
--- a/packages/push/test/PushRegistrationTest.ts
+++ b/packages/push/test/PushRegistrationTest.ts
@@ -33,17 +33,23 @@ describe("Registration tests", () => {
 
   describe("#register", async () => {
     it("should fail to register in push server", async () => {
-      registration.register(undefined as unknown as string, "cordova", ["Test"]).then(() => {
+      try {
+        await registration.register(undefined as unknown as string, "cordova", ["Test"]);
         assert.fail();
-      }).catch(() => {
+      } catch (_) {
         return "ok";
-      });
+      }
     });
 
-    it("should register in push server", async () => {
-      return registration.register("token", "cordova", ["Test"]).catch((error) => {
+    it("should register in push server", async function() {
+      // in CI environment this test sometimes fails because of the default timeout 2s
+      // increase timeout to 10s
+      this.timeout(10000);
+      try {
+        await registration.register("token", "cordova", ["Test"]);
+      } catch (error) {
         assert.fail(error);
-      });
+      }
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/aerogear/aerogear-js-sdk/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

In CI environment this test sometimes fails because of the default timeout 2s -> increased timeout to 10s.

```
> @aerogear/push@2.5.1 test /home/jenkins/workspace/integration-tests/aerogear-js-sdk/packages/push
> mocha



  Registration tests
    #register
      ✓ should fail to register in push server
      1) should register in push server


  1 passing (2s)
  1 failing

  1) Registration tests
       #register
         should register in push server:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/jenkins/workspace/integration-tests/aerogear-js-sdk/packages/push/test/PushRegistrationTest.ts)
```