### PR TITLE
AEROGEAR-9323: Migrate cordova security plugin to aerogear iroot fork

### DIFF
--- a/packages/security-cordova/plugin.xml
+++ b/packages/security-cordova/plugin.xml
@@ -7,7 +7,7 @@
 
     <name>cordova-plugin-aerogear-security</name>
 
-    <dependency id="cordova-plugin-iroot" version="0.7.0" />
+    <dependency id="@aerogear/cordova-plugin-iroot" version="0.8.1" />
 
     <dependency id="cordova-plugin-device" version="2.0.2" />
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/aerogear/aerogear-js-sdk/blob/master/CONTRIBUTING.md
-->

### Description

The `cordova-security` plugin should require `@aerogear/cordova-plugin-iroot:0.8.1` in order to fix compatibility issues with cordova 9 [1]

1. https://issues.jboss.org/browse/AEROGEAR-9087

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
