### PR TITLE
Unsubscribe Android device from Firebase topic when unregister from UPS

### DIFF
--- a/packages/push/src/PushRegistration.ts
+++ b/packages/push/src/PushRegistration.ts
@@ -117,7 +117,7 @@ export class PushRegistration {
 
     return new Promise((resolve, reject) => {
 
-      setTimeout(() => reject(), 5000);
+      setTimeout(() => reject("UPS registration timeout"), 5000);
 
       this.push.on("registration", (data: any) => {
 

--- a/packages/push/src/PushRegistration.ts
+++ b/packages/push/src/PushRegistration.ts
@@ -150,7 +150,7 @@ export class PushRegistration {
 
         } else {
           // It should never happend but...
-          return Promise.reject(new Error("Push is not properly configured"));
+          return reject(new Error("Push is not properly configured"));
         }
 
       });
@@ -203,7 +203,7 @@ export class PushRegistration {
         .catch(reject);
       } else {
         // It should never happend but...
-        return Promise.reject(new Error("Push is not properly configured"));
+        return reject(new Error("Push is not properly configured"));
       }
     });
   }

--- a/packages/push/test/PushRegistrationTest.ts
+++ b/packages/push/test/PushRegistrationTest.ts
@@ -6,9 +6,21 @@ declare var window: any;
 declare var global: any;
 
 global.window = { btoa: () => "dGVzdA==" };
-global.window.PushNotification = { init: () => "" };
+global.window.PushNotification = pushMock();
 window.localStorage = storageMock();
 window.device = { platform: "iOS" };
+
+function pushMock() {
+  return {
+    init() {
+      return {
+        on(key: string, callback: (registrationId: string) => void) {
+          callback("dummyDeviceToken");
+        }
+      };
+    }
+  };
+}
 
 function storageMock() {
   const storage: any = {};
@@ -54,7 +66,7 @@ describe("Registration tests", () => {
   describe("#register", async () => {
     it("should fail to register in push server", async () => {
       try {
-        await registration.register(undefined as unknown as string, "cordova", ["Test"]);
+        await registration.register("cordova", ["Test"]);
         assert.fail();
       } catch (_) {
         return "ok";
@@ -66,7 +78,7 @@ describe("Registration tests", () => {
       // increase timeout to 10s
       this.timeout(10000);
       try {
-        await registration.register("token", "cordova", ["Test"]);
+        await registration.register("cordova", ["Test"]);
       } catch (error) {
         assert.fail(error);
       }
@@ -77,7 +89,7 @@ describe("Registration tests", () => {
       // increase timeout to 10s
       this.timeout(10000);
       try {
-        await registration.register("token", "cordova", ["Test"]);
+        await registration.register("cordova", ["Test"]);
         assert.equal(window.localStorage.length, 1);
       } catch (error) {
         assert.fail(error);


### PR DESCRIPTION
# How to run UPS standalone

```
git clone https://github.com/aerogear/aerogear-unifiedpush-server.git
cd aerogear-unifiedpush-server
mvn clean install -DskipTests && docker run -p 9999:8080 -it aerogear/unifiedpush-configurable-container:2.2.2-SNAPSHOT
```

# How to test it

1. Register the device on UPS
1. Check if the device is listed on the UPS UI
1. Put the app in background
1. Send a message to the device (don't add any criteria) 
   * The device should receive a message show it on the 
1. Send a message to the device (using whatever category used) and check if the message was
   * The device should receive a message show it on the notification bar
1. Unregister the device on UPS
1. Check if the device gone from the UPS UI
1. Put the app in background
1. Send a message to the device (don't add any criteria) 
   * Make sure the device don't receive any message anymore
1. Send a message to the device (using whatever category used) and check if the message was
   * Make sure the device don't receive any message anymore

PS1: This step by step is by Android only
PS2: You can use [this branch](https://github.com/aerogear/ionic-showcase/tree/push-unsubscribe) to run this step by step