### PR TITLE
fix: removed extra `/` from URL

### DIFF
--- a/packages/security/src/appSecurity/AppSecurity.ts
+++ b/packages/security/src/appSecurity/AppSecurity.ts
@@ -70,9 +70,9 @@ export class AppSecurity {
    *
    * @param baseUrl
    */
-  getInitUrl(baseUrl: string): string {
+  private getInitUrl(baseUrl: string): string {
     const url = new URL(baseUrl);
-    url.pathname = '/api/init';
+    url.pathname = "/api/init";
     return url.href;
   }
 }

--- a/packages/security/src/appSecurity/AppSecurity.ts
+++ b/packages/security/src/appSecurity/AppSecurity.ts
@@ -6,10 +6,10 @@ import {
   MetricsBuilder,
   DefaultMetricsBuilder,
   isMobileCordova
- } from "@aerogear/core";
+} from "@aerogear/core";
 
 export interface AppSecurityOptions {
-   metricsBuilder?: MetricsBuilder;
+  metricsBuilder?: MetricsBuilder;
 }
 
 export class AppSecurity {
@@ -27,9 +27,7 @@ export class AppSecurity {
     const configuration = config.getConfigByType(AppSecurity.TYPE);
     if (configuration && configuration.length > 0) {
       const serviceConfiguration: ServiceConfiguration = configuration[0];
-      this.internalConfig = serviceConfiguration.config;
-      // use the configuration url in the from the incoming config file
-      this.internalConfig.url = serviceConfiguration.url;
+      this.internalConfig = serviceConfiguration;
     } else {
       console.warn("Security configuration is missing. The Security module will not work properly.");
     }
@@ -42,7 +40,7 @@ export class AppSecurity {
     const defaultMetrics = this.metricsBuilder.buildDefaultMetrics();
     const defaultMetricsPayload = await this.metricsBuilder.buildMetricsPayload("security", defaultMetrics);
 
-    const initPayload: {[key: string]: any; } = {
+    const initPayload: { [key: string]: any; } = {
       deviceId: defaultMetricsPayload.clientId,
       appId: defaultMetricsPayload.data.app.appId,
       deviceType: defaultMetricsPayload.data.device.platform,
@@ -50,7 +48,7 @@ export class AppSecurity {
       version: defaultMetricsPayload.data.app.appVersion
     };
 
-    return axios.post(`${this.internalConfig.url}/api/init`, initPayload);
+    return axios.post(this.getInitUrl(this.internalConfig.url), initPayload);
   }
 
   /**
@@ -65,5 +63,16 @@ export class AppSecurity {
    */
   public hasConfig(): boolean {
     return !!this.internalConfig;
+  }
+
+  /**
+   * Build the init URL from the base URL
+   *
+   * @param baseUrl
+   */
+  getInitUrl(baseUrl: string): string {
+    const url = new URL(baseUrl);
+    url.pathname = '/api/init';
+    return url.href;
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/aerogear/aerogear-js-sdk/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

https://issues.jboss.org/browse/AEROGEAR-9496

Remove an extra forward slash from the `/init` endpoint. The route generated by Ingress already includes a trailing forward slash so this needs to be removed.

Example Ingress route: `http://route-mobile-security-service.192.168.42.171.nip.io/`

In its present state, the init endpoint would be:

`http://route-mobile-security-service.192.168.42.171.nip.io//api/init`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added


### How

Used [The WHATWG URL API](https://nodejs.org/api/url.html#url_the_whatwg_url_api).

### Additional Notes

Tested with the Mobile Security Service and ionic-showcase:

![Screenshot from 2019-06-27 14-02-42](https://user-images.githubusercontent.com/11743717/60268664-d2510000-98e4-11e9-9489-5e8f5b90e6eb.png)
