### PR TITLE
Push message received

### DIFF
--- a/packages/push/src/PushRegistration.ts
+++ b/packages/push/src/PushRegistration.ts
@@ -7,6 +7,11 @@ import axios, { AxiosInstance } from "axios";
 
 declare var window: any;
 
+export interface PushRegistrationOptions {
+  alias?: string;
+  categories?: string[];
+}
+
 /**
  * AeroGear UPS registration SDK
  *
@@ -106,10 +111,9 @@ export class PushRegistration {
   /**
    * Register deviceToken for Android or IOS platforms
    *
-   * @param alias device alias used for registration
-   * @param categories array list of categories that device should be register to.
+   * @param options Push registration options
    */
-  public register(alias: string = "", categories: string[] = []): Promise<void> {
+  public register(options: PushRegistrationOptions = {}): Promise<void> {
 
     if (this.validationError) {
       return Promise.reject(new Error(this.validationError));
@@ -127,16 +131,18 @@ export class PushRegistration {
             "deviceType": window.device.model,
             "operatingSystem": window.device.platform,
             "osVersion": window.device.version,
-            "alias": alias,
-            "categories": categories
+            "alias": options.alias,
+            "categories": options.categories
           };
 
           return this.httpClient.post(PushRegistration.API_PATH, postData)
           .then(() => {
               if (isCordovaAndroid() && this.variantId) {
                 this.subscribeToFirebaseTopic(this.variantId);
-                for (const category of categories) {
-                  this.subscribeToFirebaseTopic(category);
+                if (options.categories) {
+                  for (const category of options.categories) {
+                    this.subscribeToFirebaseTopic(category);
+                  }
                 }
               }
 
@@ -191,8 +197,10 @@ export class PushRegistration {
 
           if (isCordovaAndroid() && this.variantId) {
             this.unsubscribeToFirebaseTopic(this.variantId);
-            for (const category of categories) {
-              this.unsubscribeToFirebaseTopic(category);
+            if (categories) {
+              for (const category of categories) {
+                this.unsubscribeToFirebaseTopic(category);
+              }
             }
           }
 

--- a/packages/push/src/PushRegistration.ts
+++ b/packages/push/src/PushRegistration.ts
@@ -7,6 +7,8 @@ import axios, { AxiosInstance } from "axios";
 
 declare var window: any;
 
+export type OnMessageReceivedCallback = (notification: any) => void;
+
 export interface PushRegistrationOptions {
   alias?: string;
   categories?: string[];
@@ -27,8 +29,13 @@ export class PushRegistration {
   public static readonly TYPE: string = "push";
   public static readonly REGISTRATION_DATA_KEY = "UPS_REGISTRATION_DATA";
 
+  public static onMessageReceived(onMessageReceivedCallback: OnMessageReceivedCallback) {
+    PushRegistration.onMessageReceivedCallback = onMessageReceivedCallback;
+  }
+
   private static readonly REGISTRATION_TIMEOUT = 5000;
   private static readonly API_PATH: string = "rest/registry/device";
+  private static onMessageReceivedCallback: OnMessageReceivedCallback;
 
   private readonly validationError?: string;
   private readonly variantId?: string;
@@ -155,6 +162,13 @@ export class PushRegistration {
 
               const storage = window.localStorage;
               storage.setItem(PushRegistration.REGISTRATION_DATA_KEY, JSON.stringify(postData));
+
+              this.push
+              .on("notification", (notification: any) => {
+                if (PushRegistration.onMessageReceivedCallback) {
+                  PushRegistration.onMessageReceivedCallback(notification);
+                }
+              });
 
               resolve();
             }

--- a/packages/push/src/PushRegistration.ts
+++ b/packages/push/src/PushRegistration.ts
@@ -10,6 +10,7 @@ declare var window: any;
 export interface PushRegistrationOptions {
   alias?: string;
   categories?: string[];
+  timeout?: number;
 }
 
 /**
@@ -26,6 +27,7 @@ export class PushRegistration {
   public static readonly TYPE: string = "push";
   public static readonly REGISTRATION_DATA_KEY = "UPS_REGISTRATION_DATA";
 
+  private static readonly REGISTRATION_TIMEOUT = 5000;
   private static readonly API_PATH: string = "rest/registry/device";
 
   private readonly validationError?: string;
@@ -115,13 +117,18 @@ export class PushRegistration {
    */
   public register(options: PushRegistrationOptions = {}): Promise<void> {
 
+    const {alias, categories, timeout} = options;
+
     if (this.validationError) {
       return Promise.reject(new Error(this.validationError));
     }
 
     return new Promise((resolve, reject) => {
 
-      setTimeout(() => reject("UPS registration timeout"), 5000);
+      setTimeout(
+        () => reject("UnifiedPush registration timeout"),
+        (timeout) ? timeout : PushRegistration.REGISTRATION_TIMEOUT
+      );
 
       this.push.on("registration", (data: any) => {
 
@@ -131,8 +138,8 @@ export class PushRegistration {
             "deviceType": window.device.model,
             "operatingSystem": window.device.platform,
             "osVersion": window.device.version,
-            "alias": options.alias,
-            "categories": options.categories
+            "alias": alias,
+            "categories": categories
           };
 
           return this.httpClient.post(PushRegistration.API_PATH, postData)

--- a/packages/push/test/PushRegistrationTest.ts
+++ b/packages/push/test/PushRegistrationTest.ts
@@ -66,7 +66,7 @@ describe("Registration tests", () => {
   describe("#register", async () => {
     it("should fail to register in push server", async () => {
       try {
-        await registration.register("cordova", ["Test"]);
+        await registration.register({alias: "cordova", categories: ["Test"]});
         assert.fail();
       } catch (_) {
         return "ok";
@@ -78,7 +78,7 @@ describe("Registration tests", () => {
       // increase timeout to 10s
       this.timeout(10000);
       try {
-        await registration.register("cordova", ["Test"]);
+        await registration.register({alias: "cordova", categories: ["Test"]});
       } catch (error) {
         assert.fail(error);
       }
@@ -89,7 +89,7 @@ describe("Registration tests", () => {
       // increase timeout to 10s
       this.timeout(10000);
       try {
-        await registration.register("cordova", ["Test"]);
+        await registration.register({alias: "cordova", categories: ["Test"]});
         assert.equal(window.localStorage.length, 1);
       } catch (error) {
         assert.fail(error);


### PR DESCRIPTION
# What this PR is about.

This is the last part of move all [phonegap-plugin-push](https://github.com/phonegap/phonegap-plugin-push) code from the [ionic-showcase](https://github.com/aerogear/ionic-showcase/blob/a2b3ed008c2de92fbc4caae89f9839f311d3e591/src/app/services/push.service.ts) to js-sdk. 

This PR change the way how to use the push on Cordva/Ionic

Right now is not required that developer need to deal with phonegap-push-plugin anymore. The js-sdk do all pre-req needed on phonegap-push-plugin behind of the scene.

Related issues: [AEROGEAR-9557](https://issues.jboss.org/browse/AEROGEAR-9557)

## Registering device

### Previous way:

```javascript
import { PushRegistration } from "@aerogear/push";

const push = PushNotification.init({
    android: {},
    ios: {
        alert: "true",
        badge: "true",
        sound: "true"
    }
});

// Registration on phonegap-push-plugin
push.on('registration', data => {
  // Registration on UnifiedPush server
  new PushRegistration(app.config).register(data.registrationId).then(() => {
    console.log('Push registration successful');
  }).catch(err => {
    console.error('Push registration unsuccessful ', err);
  });
});
```

### New way:

```javascript
import { PushRegistration } from "@aerogear/push";

new PushRegistration(new ConfigurationService(config)).register()
.then(() => {
  console.log('Push registration successful');
}).catch((err) => {
  console.error('Push registration unsuccessful ', err);
});
```

## Handling a Notification

### Previous way:

```javascript
push.on('notification', data => {
  console.log('Received a push notification', data);
});

```

### New way:

```javascript
PushRegistration.onMessageReceived((notification: any) => {
  console.log('Received a push notification', notification);
});
```

## How to test it

1. Run the ionic-showcase app using [push-message-received](https://github.com/aerogear/ionic-showcase/tree/push-message-received) branch
1. Check if the device was registered on UPS
1. Send a message from UPS panel without any criteria and check if the message was received.
1. Send a message from UPS using alias and check if the message was received.
1. Send a message from UPS using category and check if the message was received.
1. Go to settings on ionic-showcase, disable push notification and make sure the device was unregister from UP (disappear from the UPS console)
1. Send a message from UPS panel without any criteria and make sure it was not received.
1. Send a message from UPS using alias and make sure it was not received.
1. Send a message from UPS using category and make sure it was not received.

PS: The ionic showcase does not handle message with the app in background. If you wanna test message in backgroung you can add the follow code on  `home.page.ts`

```javascript
export class HomePage {
  constructor() {
    PushRegistration.onMessageReceived((notification: any) => {
      console.log('Received a push notification on home screen', notification.message);
    });
  }
}
```