### PR TITLE
fix: Add extra packages to package.json for sync

### DIFF
--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -31,29 +31,38 @@
     "access": "public"
   },
   "devDependencies": {
-    "@types/apollo-upload-client": "8.1.1",
+    "@types/apollo-upload-client": "8.1.2",
     "@types/chai": "4.1.7",
     "@types/debug": "4.1.4",
-    "@types/fetch-mock": "7.3.0",
-    "@types/graphql": "14.2.0",
-    "@types/mocha": "5.2.6",
+    "@types/fetch-mock": "7.3.1",
+    "@types/graphql": "14.2.2",
+    "@types/mocha": "5.2.7",
     "@types/ws": "6.0.1",
     "chai": "4.2.0",
-    "del": "4.1.1",
-    "fetch-mock": "7.3.3",
+    "del": "5.0.0",
+    "fetch-mock": "7.3.6",
     "graphql": "14.4.2",
     "mocha": "6.1.4",
-    "ts-node": "8.2.0",
-    "typescript": "3.4.5"
+    "ts-node": "8.3.0",
+    "typescript": "3.5.3",
+    "graphql-tag": "2.10.1"
   },
   "dependencies": {
     "@aerogear/core": "2.5.0",
-    "apollo-cache-inmemory": "1.6.2",
+    "apollo-cache-inmemory": "1.5.1",
     "apollo-cache-persist": "0.1.1",
+    "apollo-client": "2.5.1",
+    "apollo-link": "1.2.11",
+    "apollo-link-context": "1.0.17",
+    "apollo-link-http": "1.5.14",
+    "apollo-link-retry": "2.2.13",
+    "apollo-link-ws": "1.0.17",
+    "apollo-upload-client": "11.0.0",
+    "debug": "4.1.1",
     "idb-localstorage": "0.2.0",
     "offix-cache": "0.7.0-rc.1",
-    "offix-offline": "0.7.0-rc.1",
-    "util": "0.12.0"
+    "offix-offline": "0.7.0-dev.1",
+    "subscriptions-transport-ws": "0.9.16"
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/packages/sync/src/config/SyncConfig.ts
+++ b/packages/sync/src/config/SyncConfig.ts
@@ -9,7 +9,7 @@ import {
   createDefaultOfflineStorage,
   CordovaNetworkStatus,
   WebNetworkStatus,
-  clientWins,
+  UseClient,
   ConflictResolutionStrategy,
   NetworkStatus
 } from "offix-offline";
@@ -64,7 +64,7 @@ export class SyncConfig implements DataSyncConfig {
     if (clientOptions && clientOptions.conflictStrategy) {
       this.conflictStrategy = clientOptions.conflictStrategy;
     } else {
-      this.conflictStrategy = clientWins;
+      this.conflictStrategy = UseClient;
     }
     this.init(clientOptions);
   }

--- a/packages/sync/test/mock/TestUtils.ts
+++ b/packages/sync/test/mock/TestUtils.ts
@@ -1,4 +1,4 @@
-import { ApolloLink, Observable, Operation } from "apollo-link";
+import { ApolloLink, Observable, Operation, FetchResult } from "apollo-link";
 import { ExecutionResult } from "graphql";
 
 export class TestLink extends ApolloLink {
@@ -10,7 +10,7 @@ export class TestLink extends ApolloLink {
 
   public request(operation: Operation) {
     this.operations.push(operation);
-    return new Observable(observer => {
+    return new Observable<FetchResult>(observer => {
       if (operation.getContext().testError) {
         setTimeout(() => observer.error(operation.getContext().testError), 0);
         return;


### PR DESCRIPTION
Motivation - Offline package was exporting to many packages. 
This caused conflicts between existing packages that should be required on top level. Cleaned things in offix and reverted packages back to package.json