### PR TITLE
fix: remove clientId from sync header payloads

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -129,8 +129,7 @@ export class Auth {
               header: {
                 "Authorization": "Bearer " + this.auth.token
               },
-              token: this.auth.token,
-              clientId: this.internalConfig.clientId
+              token: this.auth.token
             });
           } else {
             reject("No keycloak token available");
@@ -147,5 +146,4 @@ export class Auth {
 export interface AuthContext {
   header: any;
   token: string;
-  clientId: string;
 }

--- a/packages/sync/src/auth/AuthContextProvider.ts
+++ b/packages/sync/src/auth/AuthContextProvider.ts
@@ -4,7 +4,6 @@
 export interface AuthContext {
   header: any;
   token: string;
-  clientId: string;
 }
 
 /**

--- a/packages/sync/src/links/WebsocketLink.ts
+++ b/packages/sync/src/links/WebsocketLink.ts
@@ -9,8 +9,8 @@ export const defaultWebSocketLink = (userOptions: DataSyncConfig, config: WebSoc
       // Params that can be used to send authentication token etc.
       connectionParams: async () => {
         if (userOptions.authContextProvider) {
-          const { header, clientId } = await userOptions.authContextProvider();
-          return { ...header, clientId };
+          const { header } = await userOptions.authContextProvider();
+          return { ...header };
         }
       },
       connectionCallback: options.connectionCallback,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/aerogear/aerogear-js-sdk/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

Removes the `clientId` property from the header that would be sent by the sync SDK as part of websocket connections. Relates to https://github.com/aerogear/keycloak-connect-graphql/pull/23

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
