### PR TITLE
fix(undefined url): Application Trust is breaking showcase(AGMS-662)

### DIFF
--- a/packages/security/src/appSecurity/AppSecurity.ts
+++ b/packages/security/src/appSecurity/AppSecurity.ts
@@ -27,7 +27,7 @@ export class AppSecurity {
     const configuration = config.getConfigByType(AppSecurity.TYPE);
     if (configuration && configuration.length > 0) {
       const serviceConfiguration: ServiceConfiguration = configuration[0];
-      this.internalConfig = serviceConfiguration.config;
+      this.internalConfig = serviceConfiguration;
       // use the configuration url in the from the incoming config file
       this.internalConfig.url = serviceConfiguration.url;
     } else {


### PR DESCRIPTION
## Description
fix for https://issues.jboss.org/browse/AGMS-662

## Verification 
- clone this repo and checkout this branch AGMS-662
- install the sdk 
```bash
npm i -g lerna
npm run cleanInstall
npm run build
```
- clone the ionic-showcase https://github.com/aerogear/ionic-showcase
- change the mobile-services.json to 
```json
{
  "version": 1,
  "namespace": "voyager",
  "clientId": "voyager-ionic-example",
  "services": [
    {
    "id": "security",
    "name": "security",
    "type": "security",
    "url": "https://route-mobile-security-service.apps.mdsdemo-710a.openshiftworkshop.com/"
  }
]
}

```
Change the package.json in the showcase to point to your local copy of the security package in the aerogear-js-sdk e.g.
```json
    "@aerogear/push": "2.6.0",
    "@aerogear/security": "file:/path to your clone copy/aerogear-js-sdk/packages/security",
```

- install
```bash
npm i
````
- run an android build 
```bash
ionic cordova build android
```
- copy the apk file to an android emulator 
- Check to see if the following functionality is present 

![aerogear-demo](https://user-images.githubusercontent.com/16667688/56582990-7611ed00-65d0-11e9-8e60-23d7692c9c56.gif)

