### PR TITLE
Make the version and clusterName fields optional

### DIFF
--- a/packages/core/src/config/AeroGearConfiguration.ts
+++ b/packages/core/src/config/AeroGearConfiguration.ts
@@ -5,8 +5,8 @@ import { ServiceConfiguration } from "./";
  */
 export interface AeroGearConfiguration {
 
-  readonly version: number;
-  readonly clusterName: string;
+  readonly version?: number;
+  readonly clusterName?: string;
   readonly namespace: string;
   readonly services?: ServiceConfiguration[];
 


### PR DESCRIPTION
The configuration file generated by MDC may not have `version` and `clusterName` fields. Make them optional.