### PR TITLE
Update phonegap-plugin-push to support iOS 13

### DIFF
--- a/packages/push-cordova/plugin.xml
+++ b/packages/push-cordova/plugin.xml
@@ -7,7 +7,6 @@
 
     <name>cordova-plugin-aerogear-push</name>
 
-    <dependency id="phonegap-plugin-push" version="^2.2.3"/>
-
+    <dependency id="phonegap-plugin-push" version="^2.3.0"/>
 
 </plugin>


### PR DESCRIPTION
This PR update the phonegap-plugin-push dependency to solve the token problem on iOS 13.

For more details see: [AEROGEAR-9939](https://issues.jboss.org/browse/AEROGEAR-9939)